### PR TITLE
Add blinking cursor visualization

### DIFF
--- a/internal/app/goto_ui.go
+++ b/internal/app/goto_ui.go
@@ -17,7 +17,7 @@ func (r *Runner) runGoToPrompt() {
 	input := ""
 	for {
 		// redraw buffer and draw prompt
-		drawBuffer(s, r.Buf, r.FilePath, nil)
+		drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
 		_, height := s.Size()
 		prompt := "Go to line: " + input
 		for i, ch := range prompt {
@@ -29,7 +29,7 @@ func (r *Runner) runGoToPrompt() {
 		switch ev := ev.(type) {
 		case *tcell.EventKey:
 			if ev.Key() == tcell.KeyEsc {
-				drawBuffer(s, r.Buf, r.FilePath, nil)
+				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
 				return
 			}
 			if ev.Key() == tcell.KeyEnter {
@@ -59,7 +59,7 @@ func (r *Runner) runGoToPrompt() {
 				}
 				// convert byte offset pos to rune index
 				r.Cursor = byteOffsetToRuneIndex(text, pos)
-				drawBuffer(s, r.Buf, r.FilePath, nil)
+				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
 				return
 			}
 			if ev.Key() == tcell.KeyBackspace || ev.Key() == tcell.KeyBackspace2 {

--- a/internal/app/open_ui.go
+++ b/internal/app/open_ui.go
@@ -1,90 +1,90 @@
 package app
 
 import (
-    "github.com/gdamore/tcell/v2"
+	"github.com/gdamore/tcell/v2"
 )
 
 // runOpenPrompt prompts for a file path and loads it into the buffer.
 // Esc cancels; Enter attempts to load. On error, shows a brief message and remains in the prompt.
 func (r *Runner) runOpenPrompt() {
-    if r.Screen == nil {
-        return
-    }
-    s := r.Screen
-    input := ""
-    errMsg := ""
-    for {
-        // redraw buffer and draw prompt/status
-        drawBuffer(s, r.Buf, r.FilePath, nil)
-        width, height := s.Size()
-        // Clear status line
-        for i := 0; i < width; i++ {
-            s.SetContent(i, height-1, ' ', nil, tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tcell.ColorWhite))
-        }
-        prompt := "Open: " + input
-        for i, ch := range prompt {
-            s.SetContent(i, height-1, ch, nil, tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tcell.ColorWhite))
-        }
-        if errMsg != "" {
-            // show error right-aligned
-            start := width - len([]rune(errMsg))
-            if start < len([]rune(prompt))+1 {
-                start = len([]rune(prompt)) + 1
-            }
-            idx := 0
-            for _, ch := range errMsg {
-                if start+idx < width {
-                    s.SetContent(start+idx, height-1, ch, nil, tcell.StyleDefault.Foreground(tcell.ColorRed).Background(tcell.ColorWhite))
-                }
-                idx++
-            }
-        }
-        s.Show()
+	if r.Screen == nil {
+		return
+	}
+	s := r.Screen
+	input := ""
+	errMsg := ""
+	for {
+		// redraw buffer and draw prompt/status
+		drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
+		width, height := s.Size()
+		// Clear status line
+		for i := 0; i < width; i++ {
+			s.SetContent(i, height-1, ' ', nil, tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tcell.ColorWhite))
+		}
+		prompt := "Open: " + input
+		for i, ch := range prompt {
+			s.SetContent(i, height-1, ch, nil, tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tcell.ColorWhite))
+		}
+		if errMsg != "" {
+			// show error right-aligned
+			start := width - len([]rune(errMsg))
+			if start < len([]rune(prompt))+1 {
+				start = len([]rune(prompt)) + 1
+			}
+			idx := 0
+			for _, ch := range errMsg {
+				if start+idx < width {
+					s.SetContent(start+idx, height-1, ch, nil, tcell.StyleDefault.Foreground(tcell.ColorRed).Background(tcell.ColorWhite))
+				}
+				idx++
+			}
+		}
+		s.Show()
 
-        ev := s.PollEvent()
-        switch ev := ev.(type) {
-        case *tcell.EventKey:
-            // Cancel
-            if ev.Key() == tcell.KeyEsc {
-                drawBuffer(s, r.Buf, r.FilePath, nil)
-                return
-            }
-            // Accept
-            if ev.Key() == tcell.KeyEnter {
-                path := input
-                if path == "" {
-                    errMsg = "path required"
-                    continue
-                }
-                if r.Logger != nil {
-                    r.Logger.Event("open.prompt.submit", map[string]any{"file": path})
-                }
-                if err := r.LoadFile(path); err != nil {
-                    errMsg = err.Error()
-                    if r.Logger != nil {
-                        r.Logger.Event("open.prompt.error", map[string]any{"file": path, "error": err.Error()})
-                    }
-                    continue
-                }
-                if r.Logger != nil {
-                    r.Logger.Event("open.prompt.success", map[string]any{"file": path})
-                }
-                drawBuffer(s, r.Buf, r.FilePath, nil)
-                return
-            }
-            // Backspace
-            if ev.Key() == tcell.KeyBackspace || ev.Key() == tcell.KeyBackspace2 {
-                if len(input) > 0 {
-                    input = input[:len(input)-1]
-                }
-                continue
-            }
-            // Type
-            if ev.Key() == tcell.KeyRune && ev.Modifiers() == 0 {
-                input += string(ev.Rune())
-                errMsg = ""
-                continue
-            }
-        }
-    }
+		ev := s.PollEvent()
+		switch ev := ev.(type) {
+		case *tcell.EventKey:
+			// Cancel
+			if ev.Key() == tcell.KeyEsc {
+				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
+				return
+			}
+			// Accept
+			if ev.Key() == tcell.KeyEnter {
+				path := input
+				if path == "" {
+					errMsg = "path required"
+					continue
+				}
+				if r.Logger != nil {
+					r.Logger.Event("open.prompt.submit", map[string]any{"file": path})
+				}
+				if err := r.LoadFile(path); err != nil {
+					errMsg = err.Error()
+					if r.Logger != nil {
+						r.Logger.Event("open.prompt.error", map[string]any{"file": path, "error": err.Error()})
+					}
+					continue
+				}
+				if r.Logger != nil {
+					r.Logger.Event("open.prompt.success", map[string]any{"file": path})
+				}
+				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
+				return
+			}
+			// Backspace
+			if ev.Key() == tcell.KeyBackspace || ev.Key() == tcell.KeyBackspace2 {
+				if len(input) > 0 {
+					input = input[:len(input)-1]
+				}
+				continue
+			}
+			// Type
+			if ev.Key() == tcell.KeyRune && ev.Modifiers() == 0 {
+				input += string(ev.Rune())
+				errMsg = ""
+				continue
+			}
+		}
+	}
 }

--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -117,7 +117,7 @@ func (r *Runner) Run() error {
 
 	// initial draw
 	if r.Buf != nil && r.Buf.Len() > 0 {
-		drawBuffer(r.Screen, r.Buf, r.FilePath, nil)
+		drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
 	} else {
 		drawUI(r.Screen)
 	}
@@ -138,7 +138,7 @@ func (r *Runner) Run() error {
 			if r.ShowHelp {
 				r.ShowHelp = false
 				if r.Buf != nil && r.Buf.Len() > 0 {
-					drawBuffer(r.Screen, r.Buf, r.FilePath, nil)
+					drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
 				} else {
 					drawUI(r.Screen)
 				}
@@ -157,7 +157,7 @@ func (r *Runner) Run() error {
 				drawHelp(r.Screen)
 			} else {
 				if r.Buf != nil && r.Buf.Len() > 0 {
-					drawBuffer(r.Screen, r.Buf, r.FilePath, nil)
+					drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
 				} else {
 					drawUI(r.Screen)
 				}
@@ -200,7 +200,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 		}
 		if r.Screen != nil {
 			if r.Buf != nil && r.Buf.Len() > 0 {
-				drawBuffer(r.Screen, r.Buf, r.FilePath, nil)
+				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
 			} else {
 				drawUI(r.Screen)
 			}
@@ -216,7 +216,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 				r.Logger.Event("action", map[string]any{"name": "undo", "cursor": r.Cursor, "buffer_len": r.Buf.Len()})
 			}
 			if r.Screen != nil {
-				drawBuffer(r.Screen, r.Buf, r.FilePath, nil)
+				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
 			}
 		}
 		return false
@@ -230,7 +230,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 				r.Logger.Event("action", map[string]any{"name": "redo", "cursor": r.Cursor, "buffer_len": r.Buf.Len()})
 			}
 			if r.Screen != nil {
-				drawBuffer(r.Screen, r.Buf, r.FilePath, nil)
+				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
 			}
 		}
 		return false
@@ -271,7 +271,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 			r.Logger.Event("action", map[string]any{"name": "insert", "text": text, "cursor": r.Cursor, "buffer_len": r.Buf.Len()})
 		}
 		if r.Screen != nil {
-			drawBuffer(r.Screen, r.Buf, r.FilePath, nil)
+			drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
 		}
 		return false
 	}
@@ -286,7 +286,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 				r.Logger.Event("action", map[string]any{"name": "backspace", "deleted": del, "cursor": r.Cursor, "buffer_len": r.Buf.Len()})
 			}
 			if r.Screen != nil {
-				drawBuffer(r.Screen, r.Buf, r.FilePath, nil)
+				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
 			}
 		}
 		return false
@@ -301,7 +301,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 				r.Logger.Event("action", map[string]any{"name": "delete", "deleted": del, "cursor": r.Cursor, "buffer_len": r.Buf.Len()})
 			}
 			if r.Screen != nil {
-				drawBuffer(r.Screen, r.Buf, r.FilePath, nil)
+				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
 			}
 		}
 		return false
@@ -314,7 +314,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 			r.Logger.Event("action", map[string]any{"name": "newline", "cursor": r.Cursor, "buffer_len": r.Buf.Len()})
 		}
 		if r.Screen != nil {
-			drawBuffer(r.Screen, r.Buf, r.FilePath, nil)
+			drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
 		}
 		return false
 	}
@@ -332,7 +332,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 			// Move cursor to start (now at next line)
 			r.Cursor = start
 			if r.Screen != nil {
-				drawBuffer(r.Screen, r.Buf, r.FilePath, nil)
+				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
 			}
 		}
 		return false
@@ -346,7 +346,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 				r.Logger.Event("action", map[string]any{"name": "yank", "text": text, "cursor": r.Cursor, "buffer_len": r.Buf.Len()})
 			}
 			if r.Screen != nil {
-				drawBuffer(r.Screen, r.Buf, r.FilePath, nil)
+				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
 			}
 		}
 		return false
@@ -431,20 +431,20 @@ func (r *Runner) showDialog(message string) {
 		}
 	}
 	if r.Buf != nil && r.Buf.Len() > 0 {
-		drawBuffer(s, r.Buf, r.FilePath, nil)
+		drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
 	} else {
 		drawUI(s)
 	}
 }
 
-func drawBuffer(s tcell.Screen, buf *buffer.GapBuffer, fname string, highlights []search.Range) {
+func drawBuffer(s tcell.Screen, buf *buffer.GapBuffer, fname string, highlights []search.Range, cursor int) {
 	if buf == nil {
-		drawFile(s, fname, []string{}, highlights)
+		drawFile(s, fname, []string{}, highlights, cursor)
 		return
 	}
 	content := buf.String()
 	lines := strings.Split(content, "\n")
-	drawFile(s, fname, lines, highlights)
+	drawFile(s, fname, lines, highlights, cursor)
 }
 
 // insertText inserts text at the current cursor, records history, and updates state.
@@ -499,14 +499,16 @@ func (r *Runner) currentLineBounds() (start, end int) {
 	return r.Buf.LineAt(line)
 }
 
-func drawFile(s tcell.Screen, fname string, lines []string, highlights []search.Range) {
+func drawFile(s tcell.Screen, fname string, lines []string, highlights []search.Range, cursor int) {
 	width, height := s.Size()
 	s.Clear()
 	maxLines := height - 1
 	if maxLines < 0 {
 		maxLines = 0
 	}
-	lineStart := 0 // byte offset of start of current line
+	lineStart := 0     // byte offset of start of current line
+	lineStartRune := 0 // rune offset of start of current line
+	cursorStyle := tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tcell.ColorWhite).Attributes(tcell.AttrBlink)
 	for i := 0; i < maxLines && i < len(lines); i++ {
 		line := lines[i]
 		runes := []rune(line)
@@ -549,14 +551,23 @@ func drawFile(s tcell.Screen, fname string, lines []string, highlights []search.
 		}
 		for j := 0; j < width && j < len(runes); j++ {
 			ch := runes[j]
-			if j < len(hl) && hl[j] {
+			runeIdx := lineStartRune + j
+			switch {
+			case runeIdx == cursor:
+				s.SetContent(j, i, ch, nil, cursorStyle)
+			case j < len(hl) && hl[j]:
 				s.SetContent(j, i, ch, nil, tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tcell.ColorYellow))
-			} else {
+			default:
 				s.SetContent(j, i, ch, nil, tcell.StyleDefault.Foreground(tcell.ColorWhite))
 			}
 		}
-		// advance lineStart by bytes in line + 1 for the newline
+		// if cursor at end of line, draw placeholder cell
+		if lineStartRune+len(runes) == cursor && len(runes) < width {
+			s.SetContent(len(runes), i, ' ', nil, cursorStyle)
+		}
+		// advance offsets by bytes/runes in line + 1 for the newline
 		lineStart += len([]byte(line)) + 1
+		lineStartRune += len(runes) + 1
 	}
 	status := fname + " — Press Ctrl+Q to exit"
 	if len(status) > width {

--- a/internal/app/runner_test.go
+++ b/internal/app/runner_test.go
@@ -102,7 +102,7 @@ func TestDrawFile_Highlights(t *testing.T) {
 	ranges := search.SearchAll(text, "hello")
 
 	// draw with highlights
-	drawFile(s, "f.txt", lines, ranges)
+	drawFile(s, "f.txt", lines, ranges, -1)
 
 	// check first line "hello" at (0,0..4) is highlighted
 	for x := 0; x < 5; x++ {

--- a/internal/app/save_ui.go
+++ b/internal/app/save_ui.go
@@ -25,7 +25,7 @@ func (r *Runner) runSaveAsPrompt() {
 	input := r.FilePath // prefill with current path if any
 	errMsg := ""
 	for {
-		drawBuffer(s, r.Buf, r.FilePath, nil)
+		drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
 		width, height := s.Size()
 		// Clear status line
 		for i := 0; i < width; i++ {
@@ -54,7 +54,7 @@ func (r *Runner) runSaveAsPrompt() {
 		switch ev := ev.(type) {
 		case *tcell.EventKey:
 			if ev.Key() == tcell.KeyEsc {
-				drawBuffer(s, r.Buf, r.FilePath, nil)
+				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
 				return
 			}
 			if ev.Key() == tcell.KeyEnter {

--- a/internal/app/search_ui.go
+++ b/internal/app/search_ui.go
@@ -23,7 +23,7 @@ func (r *Runner) runSearchPrompt() {
 			ranges = search.SearchAll(text, query)
 		}
 		// redraw buffer (with highlights) and draw prompt
-		drawBuffer(s, r.Buf, r.FilePath, ranges)
+		drawBuffer(s, r.Buf, r.FilePath, ranges, r.Cursor)
 		_, height := s.Size()
 		prompt := "Search: " + query
 		for i, ch := range prompt {
@@ -37,7 +37,7 @@ func (r *Runner) runSearchPrompt() {
 			// Cancel
 			if ev.Key() == tcell.KeyEsc {
 				// redraw main view without highlights
-				drawBuffer(s, r.Buf, r.FilePath, nil)
+				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
 				return
 			}
 			// Accept
@@ -58,7 +58,7 @@ func (r *Runner) runSearchPrompt() {
 					// move cursor to start of match (convert bytes->runes)
 					r.Cursor = byteOffsetToRuneIndex(text, ranges[idx].Start)
 					// after jumping we redraw and return
-					drawBuffer(s, r.Buf, r.FilePath, nil)
+					drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
 					return
 				}
 			}


### PR DESCRIPTION
## Summary
- Show the current cursor in the editor by blinking the character at that position.
- Plumb cursor information into UI prompts so the cursor indicator persists when prompts are displayed.

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689842726c18832d8f65baf4670c24da