### PR TITLE
feat: show dirty status and bottom save message

### DIFF
--- a/internal/app/goto_ui.go
+++ b/internal/app/goto_ui.go
@@ -17,7 +17,7 @@ func (r *Runner) runGoToPrompt() {
 	input := ""
 	for {
 		// redraw buffer and draw prompt
-		drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
+		drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 		_, height := s.Size()
 		prompt := "Go to line: " + input
 		for i, ch := range prompt {
@@ -29,7 +29,7 @@ func (r *Runner) runGoToPrompt() {
 		switch ev := ev.(type) {
 		case *tcell.EventKey:
 			if ev.Key() == tcell.KeyEsc {
-				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
+				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 				return
 			}
 			if ev.Key() == tcell.KeyEnter {
@@ -59,7 +59,7 @@ func (r *Runner) runGoToPrompt() {
 				}
 				// convert byte offset pos to rune index
 				r.Cursor = byteOffsetToRuneIndex(text, pos)
-				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
+				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 				return
 			}
 			if ev.Key() == tcell.KeyBackspace || ev.Key() == tcell.KeyBackspace2 {

--- a/internal/app/open_ui.go
+++ b/internal/app/open_ui.go
@@ -15,7 +15,7 @@ func (r *Runner) runOpenPrompt() {
 	errMsg := ""
 	for {
 		// redraw buffer and draw prompt/status
-		drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
+		drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 		width, height := s.Size()
 		// Clear status line
 		for i := 0; i < width; i++ {
@@ -46,7 +46,7 @@ func (r *Runner) runOpenPrompt() {
 		case *tcell.EventKey:
 			// Cancel
 			if ev.Key() == tcell.KeyEsc {
-				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
+				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 				return
 			}
 			// Accept
@@ -69,7 +69,7 @@ func (r *Runner) runOpenPrompt() {
 				if r.Logger != nil {
 					r.Logger.Event("open.prompt.success", map[string]any{"file": path})
 				}
-				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
+				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 				return
 			}
 			// Backspace

--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -117,7 +117,7 @@ func (r *Runner) Run() error {
 
 	// initial draw
 	if r.Buf != nil && r.Buf.Len() > 0 {
-		drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
+		drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 	} else {
 		drawUI(r.Screen)
 	}
@@ -138,7 +138,7 @@ func (r *Runner) Run() error {
 			if r.ShowHelp {
 				r.ShowHelp = false
 				if r.Buf != nil && r.Buf.Len() > 0 {
-					drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
+					drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 				} else {
 					drawUI(r.Screen)
 				}
@@ -157,7 +157,7 @@ func (r *Runner) Run() error {
 				drawHelp(r.Screen)
 			} else {
 				if r.Buf != nil && r.Buf.Len() > 0 {
-					drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
+					drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 				} else {
 					drawUI(r.Screen)
 				}
@@ -200,7 +200,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 		}
 		if r.Screen != nil {
 			if r.Buf != nil && r.Buf.Len() > 0 {
-				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
+				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 			} else {
 				drawUI(r.Screen)
 			}
@@ -216,7 +216,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 				r.Logger.Event("action", map[string]any{"name": "undo", "cursor": r.Cursor, "buffer_len": r.Buf.Len()})
 			}
 			if r.Screen != nil {
-				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
+				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 			}
 		}
 		return false
@@ -230,7 +230,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 				r.Logger.Event("action", map[string]any{"name": "redo", "cursor": r.Cursor, "buffer_len": r.Buf.Len()})
 			}
 			if r.Screen != nil {
-				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
+				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 			}
 		}
 		return false
@@ -269,7 +269,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 			r.Cursor--
 		}
 		if r.Screen != nil {
-			drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
+			drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 		}
 		return false
 	}
@@ -278,21 +278,21 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 			r.Cursor++
 		}
 		if r.Screen != nil {
-			drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
+			drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 		}
 		return false
 	}
 	if ev.Key() == tcell.KeyUp || (ev.Key() == tcell.KeyRune && ev.Rune() == 'p' && ev.Modifiers() == tcell.ModCtrl) {
 		r.moveCursorVertical(-1)
 		if r.Screen != nil {
-			drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
+			drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 		}
 		return false
 	}
 	if ev.Key() == tcell.KeyDown || (ev.Key() == tcell.KeyRune && ev.Rune() == 'n' && ev.Modifiers() == tcell.ModCtrl) {
 		r.moveCursorVertical(1)
 		if r.Screen != nil {
-			drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
+			drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 		}
 		return false
 	}
@@ -305,7 +305,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 			r.Logger.Event("action", map[string]any{"name": "insert", "text": text, "cursor": r.Cursor, "buffer_len": r.Buf.Len()})
 		}
 		if r.Screen != nil {
-			drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
+			drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 		}
 		return false
 	}
@@ -320,7 +320,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 				r.Logger.Event("action", map[string]any{"name": "backspace", "deleted": del, "cursor": r.Cursor, "buffer_len": r.Buf.Len()})
 			}
 			if r.Screen != nil {
-				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
+				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 			}
 		}
 		return false
@@ -335,7 +335,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 				r.Logger.Event("action", map[string]any{"name": "delete", "deleted": del, "cursor": r.Cursor, "buffer_len": r.Buf.Len()})
 			}
 			if r.Screen != nil {
-				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
+				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 			}
 		}
 		return false
@@ -348,7 +348,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 			r.Logger.Event("action", map[string]any{"name": "newline", "cursor": r.Cursor, "buffer_len": r.Buf.Len()})
 		}
 		if r.Screen != nil {
-			drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
+			drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 		}
 		return false
 	}
@@ -366,7 +366,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 			// Move cursor to start (now at next line)
 			r.Cursor = start
 			if r.Screen != nil {
-				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
+				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 			}
 		}
 		return false
@@ -380,7 +380,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 				r.Logger.Event("action", map[string]any{"name": "yank", "text": text, "cursor": r.Cursor, "buffer_len": r.Buf.Len()})
 			}
 			if r.Screen != nil {
-				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor)
+				drawBuffer(r.Screen, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 			}
 		}
 		return false
@@ -437,25 +437,29 @@ func drawHelp(s tcell.Screen) {
 	s.Show()
 }
 
-// showDialog displays a centered message with a status bar prompt and waits
-// for a key press. After dismissal it redraws the current buffer or default UI.
+// showDialog displays a message on the status bar and waits for a key press.
+// After dismissal it redraws the current buffer or default UI.
 func (r *Runner) showDialog(message string) {
 	if r.Screen == nil {
 		return
 	}
 	s := r.Screen
 	width, height := s.Size()
-	s.Clear()
-	msgX := (width - len(message)) / 2
-	msgY := height / 2
-	for i, ch := range message {
-		s.SetContent(msgX+i, msgY, ch, nil, tcell.StyleDefault.Foreground(tcell.ColorWhite))
+	// clear status line
+	for i := 0; i < width; i++ {
+		s.SetContent(i, height-1, ' ', nil, tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tcell.ColorWhite))
 	}
-	status := "Press any key to continue"
-	sbX := (width - len(status)) / 2
-	sbY := height - 1
-	for i, ch := range status {
-		s.SetContent(sbX+i, sbY, ch, nil, tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tcell.ColorWhite))
+	msg := message + " — Press any key to continue"
+	start := (width - len([]rune(msg))) / 2
+	if start < 0 {
+		start = 0
+	}
+	idx := 0
+	for _, ch := range msg {
+		if start+idx < width {
+			s.SetContent(start+idx, height-1, ch, nil, tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tcell.ColorWhite))
+		}
+		idx++
 	}
 	s.Show()
 	for {
@@ -466,20 +470,20 @@ func (r *Runner) showDialog(message string) {
 		}
 	}
 	if r.Buf != nil && r.Buf.Len() > 0 {
-		drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
+		drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 	} else {
 		drawUI(s)
 	}
 }
 
-func drawBuffer(s tcell.Screen, buf *buffer.GapBuffer, fname string, highlights []search.Range, cursor int) {
+func drawBuffer(s tcell.Screen, buf *buffer.GapBuffer, fname string, highlights []search.Range, cursor int, dirty bool) {
 	if buf == nil {
-		drawFile(s, fname, []string{}, highlights, cursor)
+		drawFile(s, fname, []string{}, highlights, cursor, dirty)
 		return
 	}
 	content := buf.String()
 	lines := strings.Split(content, "\n")
-	drawFile(s, fname, lines, highlights, cursor)
+	drawFile(s, fname, lines, highlights, cursor, dirty)
 }
 
 // insertText inserts text at the current cursor, records history, and updates state.
@@ -559,7 +563,7 @@ func (r *Runner) currentLineBounds() (start, end int) {
 	return r.Buf.LineAt(line)
 }
 
-func drawFile(s tcell.Screen, fname string, lines []string, highlights []search.Range, cursor int) {
+func drawFile(s tcell.Screen, fname string, lines []string, highlights []search.Range, cursor int, dirty bool) {
 	width, height := s.Size()
 	s.Clear()
 	maxLines := height - 1
@@ -629,7 +633,14 @@ func drawFile(s tcell.Screen, fname string, lines []string, highlights []search.
 		lineStart += len([]byte(line)) + 1
 		lineStartRune += len(runes) + 1
 	}
-	status := fname + " — Press Ctrl+Q to exit"
+	display := fname
+	if display == "" {
+		display = "[No File]"
+	}
+	if dirty {
+		display += " [+]"
+	}
+	status := display + " — Press Ctrl+Q to exit"
 	if len(status) > width {
 		status = string([]rune(status)[:width])
 	}

--- a/internal/app/runner_test.go
+++ b/internal/app/runner_test.go
@@ -138,7 +138,7 @@ func TestDrawFile_Highlights(t *testing.T) {
 	ranges := search.SearchAll(text, "hello")
 
 	// draw with highlights
-	drawFile(s, "f.txt", lines, ranges, -1)
+	drawFile(s, "f.txt", lines, ranges, -1, false)
 
 	// check first line "hello" at (0,0..4) is highlighted
 	for x := 0; x < 5; x++ {
@@ -161,6 +161,26 @@ func TestDrawFile_Highlights(t *testing.T) {
 		expStyle := tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tcell.ColorYellow)
 		if style != expStyle {
 			t.Fatalf("expected highlighted style at (%d,1) got %v", x, style)
+		}
+	}
+}
+
+func TestDrawBuffer_DirtyIndicator(t *testing.T) {
+	s := tcell.NewSimulationScreen("UTF-8")
+	if err := s.Init(); err != nil {
+		t.Fatalf("initializing simulation screen failed: %v", err)
+	}
+	defer s.Fini()
+
+	buf := buffer.NewGapBufferFromString("hello")
+	drawBuffer(s, buf, "f.txt", nil, 0, true)
+
+	_, height := s.Size()
+	expected := "f.txt [+] — Press Ctrl+Q to exit"
+	for i, r := range expected {
+		cr, _, _, _ := s.GetContent(i, height-1)
+		if cr != r {
+			t.Fatalf("expected status %q, got mismatch at %d: %q", expected, i, string(cr))
 		}
 	}
 }

--- a/internal/app/save_ui.go
+++ b/internal/app/save_ui.go
@@ -25,7 +25,7 @@ func (r *Runner) runSaveAsPrompt() {
 	input := r.FilePath // prefill with current path if any
 	errMsg := ""
 	for {
-		drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
+		drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 		width, height := s.Size()
 		// Clear status line
 		for i := 0; i < width; i++ {
@@ -54,7 +54,7 @@ func (r *Runner) runSaveAsPrompt() {
 		switch ev := ev.(type) {
 		case *tcell.EventKey:
 			if ev.Key() == tcell.KeyEsc {
-				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
+				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 				return
 			}
 			if ev.Key() == tcell.KeyEnter {

--- a/internal/app/search_ui.go
+++ b/internal/app/search_ui.go
@@ -23,7 +23,7 @@ func (r *Runner) runSearchPrompt() {
 			ranges = search.SearchAll(text, query)
 		}
 		// redraw buffer (with highlights) and draw prompt
-		drawBuffer(s, r.Buf, r.FilePath, ranges, r.Cursor)
+		drawBuffer(s, r.Buf, r.FilePath, ranges, r.Cursor, r.Dirty)
 		_, height := s.Size()
 		prompt := "Search: " + query
 		for i, ch := range prompt {
@@ -37,7 +37,7 @@ func (r *Runner) runSearchPrompt() {
 			// Cancel
 			if ev.Key() == tcell.KeyEsc {
 				// redraw main view without highlights
-				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
+				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 				return
 			}
 			// Accept
@@ -58,7 +58,7 @@ func (r *Runner) runSearchPrompt() {
 					// move cursor to start of match (convert bytes->runes)
 					r.Cursor = byteOffsetToRuneIndex(text, ranges[idx].Start)
 					// after jumping we redraw and return
-					drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor)
+					drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
 					return
 				}
 			}


### PR DESCRIPTION
## Summary
- indicate unsaved changes on the status bar with `[+]`
- display save confirmations in the bottom status bar instead of modal
- cover dirty indicator rendering with a simulation screen test

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899277b95c4832d941bcf79c4c787d3