### PR TITLE
Add basic insert and visual modes

### DIFF
--- a/internal/app/goto_ui.go
+++ b/internal/app/goto_ui.go
@@ -17,7 +17,7 @@ func (r *Runner) runGoToPrompt() {
 	input := ""
 	for {
 		// redraw buffer and draw prompt
-		drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
+		r.draw(nil)
 		_, height := s.Size()
 		prompt := "Go to line: " + input
 		for i, ch := range prompt {
@@ -29,7 +29,7 @@ func (r *Runner) runGoToPrompt() {
 		switch ev := ev.(type) {
 		case *tcell.EventKey:
 			if ev.Key() == tcell.KeyEsc {
-				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
+				r.draw(nil)
 				return
 			}
 			if ev.Key() == tcell.KeyEnter {
@@ -59,7 +59,7 @@ func (r *Runner) runGoToPrompt() {
 				}
 				// convert byte offset pos to rune index
 				r.Cursor = byteOffsetToRuneIndex(text, pos)
-				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
+				r.draw(nil)
 				return
 			}
 			if ev.Key() == tcell.KeyBackspace || ev.Key() == tcell.KeyBackspace2 {

--- a/internal/app/open_ui.go
+++ b/internal/app/open_ui.go
@@ -15,7 +15,7 @@ func (r *Runner) runOpenPrompt() {
 	errMsg := ""
 	for {
 		// redraw buffer and draw prompt/status
-		drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
+		r.draw(nil)
 		width, height := s.Size()
 		// Clear status line
 		for i := 0; i < width; i++ {
@@ -46,7 +46,7 @@ func (r *Runner) runOpenPrompt() {
 		case *tcell.EventKey:
 			// Cancel
 			if ev.Key() == tcell.KeyEsc {
-				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
+				r.draw(nil)
 				return
 			}
 			// Accept
@@ -69,7 +69,7 @@ func (r *Runner) runOpenPrompt() {
 				if r.Logger != nil {
 					r.Logger.Event("open.prompt.success", map[string]any{"file": path})
 				}
-				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
+				r.draw(nil)
 				return
 			}
 			// Backspace

--- a/internal/app/save_ui.go
+++ b/internal/app/save_ui.go
@@ -25,7 +25,7 @@ func (r *Runner) runSaveAsPrompt() {
 	input := r.FilePath // prefill with current path if any
 	errMsg := ""
 	for {
-		drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
+		r.draw(nil)
 		width, height := s.Size()
 		// Clear status line
 		for i := 0; i < width; i++ {
@@ -54,7 +54,7 @@ func (r *Runner) runSaveAsPrompt() {
 		switch ev := ev.(type) {
 		case *tcell.EventKey:
 			if ev.Key() == tcell.KeyEsc {
-				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
+				r.draw(nil)
 				return
 			}
 			if ev.Key() == tcell.KeyEnter {

--- a/internal/app/search_ui.go
+++ b/internal/app/search_ui.go
@@ -23,7 +23,7 @@ func (r *Runner) runSearchPrompt() {
 			ranges = search.SearchAll(text, query)
 		}
 		// redraw buffer (with highlights) and draw prompt
-		drawBuffer(s, r.Buf, r.FilePath, ranges, r.Cursor, r.Dirty)
+		r.draw(ranges)
 		_, height := s.Size()
 		prompt := "Search: " + query
 		for i, ch := range prompt {
@@ -37,7 +37,7 @@ func (r *Runner) runSearchPrompt() {
 			// Cancel
 			if ev.Key() == tcell.KeyEsc {
 				// redraw main view without highlights
-				drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
+				r.draw(nil)
 				return
 			}
 			// Accept
@@ -58,7 +58,7 @@ func (r *Runner) runSearchPrompt() {
 					// move cursor to start of match (convert bytes->runes)
 					r.Cursor = byteOffsetToRuneIndex(text, ranges[idx].Start)
 					// after jumping we redraw and return
-					drawBuffer(s, r.Buf, r.FilePath, nil, r.Cursor, r.Dirty)
+					r.draw(nil)
 					return
 				}
 			}


### PR DESCRIPTION
## Summary
- introduce editor modes with insert as default and visual mode toggled via Escape
- highlight selections in visual mode and centralize screen rendering
- update prompts to draw using new helper so selections persist

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68992986badc832daca3f5dc43091642