### PR TITLE
Add visual mode paste and Ctrl-U paste

### DIFF
--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -591,6 +591,31 @@ func (r *Runner) handleVisualKey(ev *tcell.EventKey) bool {
 		r.VisualStart = -1
 		r.draw(nil)
 		return false
+	case ev.Key() == tcell.KeyRune && ev.Rune() == 'p' && ev.Modifiers() == 0:
+		if r.Buf != nil && r.KillRing.HasData() {
+			start := r.VisualStart
+			end := r.Cursor
+			if start > end {
+				start, end = end, start
+			}
+			if start < end {
+				// remove current selection
+				removed := string(r.Buf.Slice(start, end))
+				_ = r.deleteRange(start, end, removed)
+				r.Cursor = start
+			} else {
+				r.Cursor = start
+			}
+			text := r.KillRing.Get()
+			r.insertText(text)
+			if r.Logger != nil {
+				r.Logger.Event("action", map[string]any{"name": "paste.visual", "text": text, "cursor": r.Cursor, "buffer_len": r.Buf.Len()})
+			}
+		}
+		r.Mode = ModeInsert
+		r.VisualStart = -1
+		r.draw(nil)
+		return false
 	}
 	// ignore other keys in visual mode
 	return false


### PR DESCRIPTION
## Summary
- allow pasting kill ring contents over a visual selection with `p`
- support `Ctrl+U` to paste from the kill ring while inserting
- test visual-mode pasting

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68992ea0b0dc832dbdb2bbe04ac5331c