### PR TITLE
Handle dedicated Ctrl navigation keys

### DIFF
--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -292,7 +292,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 	}
 
 	// Arrow keys and basic cursor movement (Ctrl+B/F for left/right, Ctrl+P/N for up/down)
-	if ev.Key() == tcell.KeyLeft || (ev.Key() == tcell.KeyRune && ev.Rune() == 'b' && ev.Modifiers() == tcell.ModCtrl) {
+	if ev.Key() == tcell.KeyLeft || ev.Key() == tcell.KeyCtrlB || (ev.Key() == tcell.KeyRune && ev.Rune() == 'b' && ev.Modifiers() == tcell.ModCtrl) {
 		if r.Cursor > 0 {
 			r.Cursor--
 		}
@@ -301,7 +301,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 		}
 		return false
 	}
-	if ev.Key() == tcell.KeyRight || (ev.Key() == tcell.KeyRune && ev.Rune() == 'f' && ev.Modifiers() == tcell.ModCtrl) {
+	if ev.Key() == tcell.KeyRight || ev.Key() == tcell.KeyCtrlF || (ev.Key() == tcell.KeyRune && ev.Rune() == 'f' && ev.Modifiers() == tcell.ModCtrl) {
 		if r.Buf != nil && r.Cursor < r.Buf.Len() {
 			r.Cursor++
 		}
@@ -310,14 +310,14 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 		}
 		return false
 	}
-	if ev.Key() == tcell.KeyUp || (ev.Key() == tcell.KeyRune && ev.Rune() == 'p' && ev.Modifiers() == tcell.ModCtrl) {
+	if ev.Key() == tcell.KeyUp || ev.Key() == tcell.KeyCtrlP || (ev.Key() == tcell.KeyRune && ev.Rune() == 'p' && ev.Modifiers() == tcell.ModCtrl) {
 		r.moveCursorVertical(-1)
 		if r.Screen != nil {
 			r.draw(nil)
 		}
 		return false
 	}
-	if ev.Key() == tcell.KeyDown || (ev.Key() == tcell.KeyRune && ev.Rune() == 'n' && ev.Modifiers() == tcell.ModCtrl) {
+	if ev.Key() == tcell.KeyDown || ev.Key() == tcell.KeyCtrlN || (ev.Key() == tcell.KeyRune && ev.Rune() == 'n' && ev.Modifiers() == tcell.ModCtrl) {
 		r.moveCursorVertical(1)
 		if r.Screen != nil {
 			r.draw(nil)

--- a/internal/app/runner_test.go
+++ b/internal/app/runner_test.go
@@ -90,37 +90,62 @@ func TestRunner_BackspaceAndDelete(t *testing.T) {
 
 func TestRunner_CursorMoveHorizontal(t *testing.T) {
 	r := &Runner{Buf: buffer.NewGapBufferFromString("ab"), Cursor: 1}
+	// Right arrow
 	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRight, 0, 0))
 	if r.Cursor != 2 {
 		t.Fatalf("expected cursor 2 after right arrow, got %d", r.Cursor)
 	}
+	// Dedicated Ctrl+B key
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyCtrlB, 0, 0))
+	if r.Cursor != 1 {
+		t.Fatalf("expected cursor 1 after KeyCtrlB, got %d", r.Cursor)
+	}
+	// Dedicated Ctrl+F key
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyCtrlF, 0, 0))
+	if r.Cursor != 2 {
+		t.Fatalf("expected cursor 2 after KeyCtrlF, got %d", r.Cursor)
+	}
+	// Rune with Ctrl modifiers
 	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'b', tcell.ModCtrl))
 	if r.Cursor != 1 {
-		t.Fatalf("expected cursor 1 after Ctrl+B, got %d", r.Cursor)
+		t.Fatalf("expected cursor 1 after Ctrl+B rune, got %d", r.Cursor)
 	}
 	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'f', tcell.ModCtrl))
 	if r.Cursor != 2 {
-		t.Fatalf("expected cursor 2 after Ctrl+F, got %d", r.Cursor)
+		t.Fatalf("expected cursor 2 after Ctrl+F rune, got %d", r.Cursor)
 	}
 }
 
 func TestRunner_CursorMoveVertical(t *testing.T) {
 	r := &Runner{Buf: buffer.NewGapBufferFromString("ab\ncde\nf"), Cursor: 1}
+	// Down arrow
 	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyDown, 0, 0))
 	if r.Cursor != 4 {
 		t.Fatalf("expected cursor 4 after down arrow, got %d", r.Cursor)
 	}
-	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'n', tcell.ModCtrl))
+	// Dedicated Ctrl+N key
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyCtrlN, 0, 0))
 	if r.Cursor != 8 {
-		t.Fatalf("expected cursor 8 after Ctrl+N, got %d", r.Cursor)
+		t.Fatalf("expected cursor 8 after KeyCtrlN, got %d", r.Cursor)
 	}
+	// Up arrow
 	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyUp, 0, 0))
 	if r.Cursor != 4 {
 		t.Fatalf("expected cursor 4 after up arrow, got %d", r.Cursor)
 	}
+	// Dedicated Ctrl+P key
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyCtrlP, 0, 0))
+	if r.Cursor != 1 {
+		t.Fatalf("expected cursor 1 after KeyCtrlP, got %d", r.Cursor)
+	}
+	// Rune with Ctrl modifiers
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'n', tcell.ModCtrl))
+	if r.Cursor != 4 {
+		t.Fatalf("expected cursor 4 after Ctrl+N rune, got %d", r.Cursor)
+	}
 	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'p', tcell.ModCtrl))
 	if r.Cursor != 1 {
-		t.Fatalf("expected cursor 1 after Ctrl+P, got %d", r.Cursor)
+		t.Fatalf("expected cursor 1 after Ctrl+P rune, got %d", r.Cursor)
 	}
 }
 


### PR DESCRIPTION
## Summary
- support tcell's dedicated Ctrl navigation keys (Ctrl+B/F/P/N)
- expand cursor movement tests to cover both rune+Ctrl and dedicated key events

## Testing
- `go test ./internal/app -run TestRunner_CursorMoveHorizontal -v`
- `go test ./internal/app -run TestRunner_CursorMoveVertical -v`
- `go test ./internal/app -v`


------
https://chatgpt.com/codex/tasks/task_e_689931401f2c832d9dc0d130c60ca087