### PR TITLE
Move paste to normal mode and add green cursor

### DIFF
--- a/internal/app/runner_test.go
+++ b/internal/app/runner_test.go
@@ -294,24 +294,16 @@ func TestRunner_VisualYank(t *testing.T) {
 	}
 }
 
-func TestRunner_VisualPaste(t *testing.T) {
+func TestRunner_NormalPaste(t *testing.T) {
 	r := &Runner{Buf: buffer.NewGapBufferFromString("hello"), Cursor: 1, History: history.New()}
 	r.KillRing.Set("XY")
-	// Enter visual mode
-	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'v', 0))
-	// Extend selection to include "el"
-	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRight, 0, 0))
-	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRight, 0, 0))
-	// Paste over selection
+	// Paste at cursor in normal mode
 	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'p', 0))
-	if got := r.Buf.String(); got != "hXYlo" {
-		t.Fatalf("expected buffer 'hXYlo' after paste, got %q", got)
+	if got := r.Buf.String(); got != "hXYello" {
+		t.Fatalf("expected buffer 'hXYello' after paste, got %q", got)
 	}
 	if r.Mode != ModeNormal {
-		t.Fatalf("expected mode to return to normal after paste")
-	}
-	if r.VisualStart != -1 {
-		t.Fatalf("expected visual start reset after paste")
+		t.Fatalf("expected mode to remain normal after paste")
 	}
 	if r.Cursor != 1+len("XY") {
 		t.Fatalf("expected cursor at %d after paste, got %d", 1+len("XY"), r.Cursor)

--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,7 @@ Done when: Search works across file; tests cover search index and wrap-around.
 M4 — Clipboard-like actions (line kill/yank) & Undo/Redo v1
 	•	Ctrl+K: cut line to an internal kill ring (single slot is fine for v1).
 	•	Ctrl+U: paste line.
+	•	p: paste from the kill ring in normal mode.
 	•	Ctrl+Z/Ctrl+Y: undo/redo using a simple history stack.
 Done when: Basic cut/paste and undo/redo function with tests on edit history.
 
@@ -440,7 +441,7 @@ The following is a concrete, actionable plan for the next milestones (M3–M5). 
   - Tasks:
     - Implement a simple kill-ring structure (one slot v1) in pkg/history or pkg/clipboard.
     - Add undo/redo stack in pkg/history with basic command records for Insert/Delete operations.
-    - Bindings: Ctrl+K cuts the current line (store in kill-ring and delete), Ctrl+U pastes the kill ring at cursor, Ctrl+Z/Ctrl+Y undo/redo.
+    - Bindings: Ctrl+K cuts the current line (store in kill-ring and delete), p pastes the kill ring at cursor, Ctrl+Z/Ctrl+Y undo/redo.
     - Tests for history correctness and kill/paste round-trips.
   - Files:
     - pkg/history/history.go, pkg/history/history_test.go


### PR DESCRIPTION
## Summary
- Paste with `p` in normal mode and drop paste from visual mode
- Show normal-mode paste in help and docs
- Use green cursor for normal mode

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689937273778832dbc272c30b3726a97