### PR TITLE
Add append and open-line commands

### DIFF
--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -204,6 +204,13 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 			r.Mode = ModeInsert
 			r.draw(nil)
 			return false
+		case 'a':
+			if r.Buf != nil && r.Cursor < r.Buf.Len() {
+				r.Cursor++
+			}
+			r.Mode = ModeInsert
+			r.draw(nil)
+			return false
 		case 'v':
 			r.Mode = ModeVisual
 			r.VisualStart = r.Cursor
@@ -528,8 +535,8 @@ func drawHelp(s tcell.Screen) {
 		"- Ctrl+Z / Ctrl+Y: Undo / Redo",
 		"- Ctrl+A/Ctrl+E: Line start/end (insert)",
 		"- Modes: Normal (default), Insert (i), Visual (v)",
-		"- Normal mode: p paste",
-		"- Visual mode: y copy, x cut",
+		"- Normal mode: p paste, a append",
+		"- Visual mode: y copy, x cut, o open line",
 		"- Arrow keys or Ctrl+B/F/P/N: Move cursor",
 		"- Enter: New line; Backspace/Delete: Remove",
 		"- Typing: Inserts characters",
@@ -648,6 +655,16 @@ func (r *Runner) handleVisualKey(ev *tcell.EventKey) bool {
 		return false
 	case ev.Key() == tcell.KeyDown || (ev.Key() == tcell.KeyRune && ev.Rune() == 'j' && ev.Modifiers() == 0):
 		r.moveCursorVertical(1)
+		r.draw(nil)
+		return false
+	case ev.Key() == tcell.KeyRune && ev.Rune() == 'o' && ev.Modifiers() == 0:
+		if r.Buf != nil {
+			_, end := r.currentLineBounds()
+			r.Cursor = end
+			r.insertText("\n")
+		}
+		r.Mode = ModeInsert
+		r.VisualStart = -1
 		r.draw(nil)
 		return false
 	case ev.Key() == tcell.KeyRune && ev.Rune() == 'y' && ev.Modifiers() == 0:

--- a/internal/app/runner_test.go
+++ b/internal/app/runner_test.go
@@ -345,6 +345,39 @@ func TestRunner_NormalPaste(t *testing.T) {
 	}
 }
 
+func TestNormalModeAppend(t *testing.T) {
+	r := &Runner{Buf: buffer.NewGapBufferFromString("ab"), Cursor: 0}
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'a', 0))
+	if r.Mode != ModeInsert {
+		t.Fatalf("expected insert mode after 'a'")
+	}
+	if r.Cursor != 1 {
+		t.Fatalf("expected cursor at 1 after 'a', got %d", r.Cursor)
+	}
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'X', 0))
+	if got := r.Buf.String(); got != "aXb" {
+		t.Fatalf("expected buffer 'aXb', got %q", got)
+	}
+}
+
+func TestVisualModeOpenLine(t *testing.T) {
+	r := &Runner{Buf: buffer.NewGapBufferFromString("hello"), Cursor: 0}
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'v', 0))
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'o', 0))
+	if r.Mode != ModeInsert {
+		t.Fatalf("expected insert mode after 'o'")
+	}
+	if r.VisualStart != -1 {
+		t.Fatalf("expected visual start reset after 'o'")
+	}
+	if got := r.Buf.String(); got != "hello\n" {
+		t.Fatalf("expected buffer 'hello\\n', got %q", got)
+	}
+	if r.Cursor != len("hello\n") {
+		t.Fatalf("expected cursor at %d after open line, got %d", len("hello\n"), r.Cursor)
+	}
+}
+
 func TestRunner_UndoRedo(t *testing.T) {
 	r := &Runner{Buf: buffer.NewGapBuffer(0), History: history.New()}
 	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'i', 0))


### PR DESCRIPTION
## Summary
- support `a` in normal mode to enter insert mode after the cursor
- allow `o` in visual mode to open a new line and enter insert mode
- document new keybindings in the help overlay and add tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68994c2b9f1c832d9e523718b6bd919e