### PR TITLE
Add open-line command and line navigation keys

### DIFF
--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -228,6 +228,38 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 				}
 			}
 			return false
+		case 'o':
+			if r.Buf != nil {
+				_, end := r.currentLineBounds()
+				r.Cursor = end
+				r.insertText("\n")
+			}
+			r.Mode = ModeInsert
+			if r.Screen != nil {
+				r.draw(nil)
+			}
+			return false
+		case '$':
+			if r.Buf != nil {
+				_, end := r.currentLineBounds()
+				if end > 0 && string(r.Buf.Slice(end-1, end)) == "\n" {
+					end--
+				}
+				r.Cursor = end
+			}
+			if r.Screen != nil {
+				r.draw(nil)
+			}
+			return false
+		case '0':
+			if r.Buf != nil {
+				start, _ := r.currentLineBounds()
+				r.Cursor = start
+			}
+			if r.Screen != nil {
+				r.draw(nil)
+			}
+			return false
 		}
 	}
 	if r.Mode == ModeVisual && ev.Key() == tcell.KeyRune && ev.Rune() == 'v' && ev.Modifiers() == 0 {
@@ -655,6 +687,23 @@ func (r *Runner) handleVisualKey(ev *tcell.EventKey) bool {
 		return false
 	case ev.Key() == tcell.KeyDown || (ev.Key() == tcell.KeyRune && ev.Rune() == 'j' && ev.Modifiers() == 0):
 		r.moveCursorVertical(1)
+		r.draw(nil)
+		return false
+	case ev.Key() == tcell.KeyRune && ev.Rune() == '$' && ev.Modifiers() == 0:
+		if r.Buf != nil {
+			_, end := r.currentLineBounds()
+			if end > 0 && string(r.Buf.Slice(end-1, end)) == "\n" {
+				end--
+			}
+			r.Cursor = end
+		}
+		r.draw(nil)
+		return false
+	case ev.Key() == tcell.KeyRune && ev.Rune() == '0' && ev.Modifiers() == 0:
+		if r.Buf != nil {
+			start, _ := r.currentLineBounds()
+			r.Cursor = start
+		}
 		r.draw(nil)
 		return false
 	case ev.Key() == tcell.KeyRune && ev.Rune() == 'o' && ev.Modifiers() == 0:

--- a/internal/app/runner_test.go
+++ b/internal/app/runner_test.go
@@ -173,6 +173,46 @@ func TestModeTransitions(t *testing.T) {
 	}
 }
 
+func TestOpenLineFromNormalMode(t *testing.T) {
+	r := &Runner{Buf: buffer.NewGapBufferFromString("hello"), Mode: ModeNormal}
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'o', 0))
+	if got := r.Buf.String(); got != "hello\n" {
+		t.Fatalf("expected buffer 'hello\\n' after open line, got %q", got)
+	}
+	if r.Mode != ModeInsert {
+		t.Fatalf("expected mode insert after 'o', got %v", r.Mode)
+	}
+	if r.Cursor != len("hello\n") {
+		t.Fatalf("expected cursor at end of new line, got %d", r.Cursor)
+	}
+}
+
+func TestLineNavigationNormalMode(t *testing.T) {
+	r := &Runner{Buf: buffer.NewGapBufferFromString("abc\ndef"), Cursor: 1, Mode: ModeNormal}
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, '$', 0))
+	if r.Cursor != 3 {
+		t.Fatalf("expected cursor at end of line, got %d", r.Cursor)
+	}
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, '0', 0))
+	if r.Cursor != 0 {
+		t.Fatalf("expected cursor at start of line, got %d", r.Cursor)
+	}
+}
+
+func TestLineNavigationVisualMode(t *testing.T) {
+	r := &Runner{Buf: buffer.NewGapBufferFromString("abc\ndef"), Cursor: 1, Mode: ModeNormal}
+	// enter visual mode
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'v', 0))
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, '$', 0))
+	if r.Cursor != 3 {
+		t.Fatalf("expected cursor at end of line in visual mode, got %d", r.Cursor)
+	}
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, '0', 0))
+	if r.Cursor != 0 {
+		t.Fatalf("expected cursor at start of line in visual mode, got %d", r.Cursor)
+	}
+}
+
 func TestVisualCutX(t *testing.T) {
 	r := &Runner{Buf: buffer.NewGapBufferFromString("hello"), KillRing: history.KillRing{}}
 	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'v', 0))


### PR DESCRIPTION
## Summary
- support `o` in normal mode to open a new line and switch to insert
- add `$` and `0` movement commands in normal and visual modes
- cover new behavior with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899538919d4832d82428aceda5016b6