### PR TITLE
feat: introduce mini-buffer window for dialogs

### DIFF
--- a/internal/app/open_ui.go
+++ b/internal/app/open_ui.go
@@ -14,38 +14,21 @@ func (r *Runner) runOpenPrompt() {
 	input := ""
 	errMsg := ""
 	for {
-		// redraw buffer and draw prompt/status
-		r.draw(nil)
-		width, height := s.Size()
-		// Clear status line
-		for i := 0; i < width; i++ {
-			s.SetContent(i, height-1, ' ', nil, tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tcell.ColorWhite))
-		}
-		prompt := "Open: " + input
-		for i, ch := range prompt {
-			s.SetContent(i, height-1, ch, nil, tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tcell.ColorWhite))
-		}
+		lines := []string{"Open: " + input}
 		if errMsg != "" {
-			// show error right-aligned
-			start := width - len([]rune(errMsg))
-			if start < len([]rune(prompt))+1 {
-				start = len([]rune(prompt)) + 1
-			}
-			idx := 0
-			for _, ch := range errMsg {
-				if start+idx < width {
-					s.SetContent(start+idx, height-1, ch, nil, tcell.StyleDefault.Foreground(tcell.ColorRed).Background(tcell.ColorWhite))
-				}
-				idx++
-			}
+			lines = append(lines, errMsg)
+		} else {
+			lines = append(lines, "Enter to open, Esc to cancel")
 		}
-		s.Show()
+		r.setMiniBuffer(lines)
+		r.draw(nil)
 
 		ev := s.PollEvent()
 		switch ev := ev.(type) {
 		case *tcell.EventKey:
 			// Cancel
 			if ev.Key() == tcell.KeyEsc {
+				r.clearMiniBuffer()
 				r.draw(nil)
 				return
 			}
@@ -69,6 +52,7 @@ func (r *Runner) runOpenPrompt() {
 				if r.Logger != nil {
 					r.Logger.Event("open.prompt.success", map[string]any{"file": path})
 				}
+				r.clearMiniBuffer()
 				r.draw(nil)
 				return
 			}

--- a/internal/app/quit_ui.go
+++ b/internal/app/quit_ui.go
@@ -1,0 +1,29 @@
+package app
+
+import "github.com/gdamore/tcell/v2"
+
+// runQuitPrompt shows a confirmation mini-buffer when the buffer is dirty.
+// It returns true if the user confirms quit.
+func (r *Runner) runQuitPrompt() bool {
+	if r.Screen == nil {
+		return true
+	}
+	s := r.Screen
+	r.setMiniBuffer([]string{"Unsaved changes. Quit without saving? (y/n)"})
+	r.draw(nil)
+	for {
+		ev := s.PollEvent()
+		switch ev := ev.(type) {
+		case *tcell.EventKey:
+			if ev.Key() == tcell.KeyEsc || (ev.Key() == tcell.KeyRune && (ev.Rune() == 'n' || ev.Rune() == 'N')) {
+				r.clearMiniBuffer()
+				r.draw(nil)
+				return false
+			}
+			if ev.Key() == tcell.KeyRune && (ev.Rune() == 'y' || ev.Rune() == 'Y') {
+				r.clearMiniBuffer()
+				return true
+			}
+		}
+	}
+}

--- a/internal/app/save_ui.go
+++ b/internal/app/save_ui.go
@@ -25,35 +25,20 @@ func (r *Runner) runSaveAsPrompt() {
 	input := r.FilePath // prefill with current path if any
 	errMsg := ""
 	for {
-		r.draw(nil)
-		width, height := s.Size()
-		// Clear status line
-		for i := 0; i < width; i++ {
-			s.SetContent(i, height-1, ' ', nil, tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tcell.ColorWhite))
-		}
-		prompt := "Save As: " + input
-		for i, ch := range prompt {
-			s.SetContent(i, height-1, ch, nil, tcell.StyleDefault.Foreground(tcell.ColorBlack).Background(tcell.ColorWhite))
-		}
+		lines := []string{"Save As: " + input}
 		if errMsg != "" {
-			start := width - len([]rune(errMsg))
-			if start < len([]rune(prompt))+1 {
-				start = len([]rune(prompt)) + 1
-			}
-			idx := 0
-			for _, ch := range errMsg {
-				if start+idx < width {
-					s.SetContent(start+idx, height-1, ch, nil, tcell.StyleDefault.Foreground(tcell.ColorRed).Background(tcell.ColorWhite))
-				}
-				idx++
-			}
+			lines = append(lines, errMsg)
+		} else {
+			lines = append(lines, "Enter to save, Esc to cancel")
 		}
-		s.Show()
+		r.setMiniBuffer(lines)
+		r.draw(nil)
 
 		ev := s.PollEvent()
 		switch ev := ev.(type) {
 		case *tcell.EventKey:
 			if ev.Key() == tcell.KeyEsc {
+				r.clearMiniBuffer()
 				r.draw(nil)
 				return
 			}
@@ -66,6 +51,7 @@ func (r *Runner) runSaveAsPrompt() {
 					errMsg = err.Error()
 					continue
 				}
+				r.clearMiniBuffer()
 				r.showDialog("Saved " + input)
 				return
 			}


### PR DESCRIPTION
## Summary
- add a temporary mini-buffer above the status line and render logic
- show save/open/search prompts and status messages in the mini-buffer
- confirm quitting unsaved buffers via a mini-buffer prompt

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68996c46cf48832d96a7efeb18abec9a