### PR TITLE
Add basic YAML config and keymap system

### DIFF
--- a/cmd/texteditor/main.go
+++ b/cmd/texteditor/main.go
@@ -1,38 +1,45 @@
 package main
 
 import (
-    "fmt"
-    "os"
+	"fmt"
+	"os"
 
-    "example.com/texteditor/internal/app"
-    "example.com/texteditor/pkg/logs"
+	"example.com/texteditor/internal/app"
+	"example.com/texteditor/pkg/config"
+	"example.com/texteditor/pkg/logs"
 )
 
 // main wires the CLI to the application runner which supports typing,
 // saving, search, and other keybindings. It optionally loads a file
 // provided as the first argument and starts the event loop.
 func main() {
-    r := app.New()
-    // Initialize logger from env for CLI runs
-    r.Logger = logs.NewFromEnv()
+	r := app.New()
+	// Initialize logger from env for CLI runs
+	r.Logger = logs.NewFromEnv()
 
-    // Load optional file path argument
-    if len(os.Args) > 1 {
-        arg := os.Args[1]
-        if r.Logger != nil {
-            r.Logger.Event("cli.open.arg", map[string]any{"file": arg})
-        }
-        if err := r.LoadFile(arg); err != nil {
-            // Non-fatal: start editor with empty buffer and report error to stderr
-            fmt.Fprintf(os.Stderr, "failed to load %s: %v\n", arg, err)
-            if r.Logger != nil {
-                r.Logger.Event("cli.open.error", map[string]any{"file": arg, "error": err.Error()})
-            }
-        }
-    }
+	if cfg, err := config.LoadDefault(); err != nil {
+		fmt.Fprintf(os.Stderr, "config error: %v\n", err)
+	} else {
+		r.Keymap = cfg.Keymap
+	}
 
-    if err := r.Run(); err != nil {
-        fmt.Fprintln(os.Stderr, err)
-        os.Exit(1)
-    }
+	// Load optional file path argument
+	if len(os.Args) > 1 {
+		arg := os.Args[1]
+		if r.Logger != nil {
+			r.Logger.Event("cli.open.arg", map[string]any{"file": arg})
+		}
+		if err := r.LoadFile(arg); err != nil {
+			// Non-fatal: start editor with empty buffer and report error to stderr
+			fmt.Fprintf(os.Stderr, "failed to load %s: %v\n", arg, err)
+			if r.Logger != nil {
+				r.Logger.Event("cli.open.error", map[string]any{"file": arg, "error": err.Error()})
+			}
+		}
+	}
+
+	if err := r.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }

--- a/internal/app/runner_test.go
+++ b/internal/app/runner_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"example.com/texteditor/pkg/buffer"
+	"example.com/texteditor/pkg/config"
 	"example.com/texteditor/pkg/history"
 	"example.com/texteditor/pkg/search"
 	"github.com/gdamore/tcell/v2"
@@ -25,6 +26,22 @@ func TestHandleKeyEvent_CtrlQ_Key(t *testing.T) {
 	ev := tcell.NewEventKey(tcell.KeyCtrlQ, 0, 0)
 	if !r.handleKeyEvent(ev) {
 		t.Fatalf("expected KeyCtrlQ event to signal quit")
+	}
+}
+
+func TestHandleKeyEvent_RemapQuit(t *testing.T) {
+	kb, err := config.ParseKeybinding("Ctrl+X")
+	if err != nil {
+		t.Fatalf("parse keybinding: %v", err)
+	}
+	r := &Runner{Keymap: config.DefaultKeymap()}
+	r.Keymap["quit"] = kb
+
+	if r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'q', tcell.ModCtrl)) {
+		t.Fatalf("Ctrl+Q should not quit after remap")
+	}
+	if !r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'x', tcell.ModCtrl)) {
+		t.Fatalf("Ctrl+X should quit after remap")
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,149 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// Keybinding represents a single key combination.
+type Keybinding struct {
+	Key  tcell.Key
+	Rune rune
+	Mod  tcell.ModMask
+}
+
+// Config holds user configuration values.
+type Config struct {
+	Keymap map[string]Keybinding `yaml:"keymap"`
+}
+
+// Default returns a Config with default key mappings.
+func Default() *Config {
+	return &Config{Keymap: DefaultKeymap()}
+}
+
+// DefaultKeymap provides builtin command bindings.
+func DefaultKeymap() map[string]Keybinding {
+	return map[string]Keybinding{
+		"quit":   mustParse("Ctrl+Q"),
+		"save":   mustParse("Ctrl+S"),
+		"search": mustParse("Ctrl+W"),
+	}
+}
+
+// Load loads configuration from the provided path. If the file does not
+// exist, defaults are returned.
+func Load(path string) (*Config, error) {
+	cfg := Default()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cfg, nil
+		}
+		return nil, err
+	}
+	lines := strings.Split(string(data), "\n")
+	inKeymap := false
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if !inKeymap {
+			if line == "keymap:" {
+				inKeymap = true
+			}
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			return nil, errors.New("invalid config line: " + line)
+		}
+		cmd := strings.TrimSpace(parts[0])
+		binding := strings.TrimSpace(parts[1])
+		kb, err := ParseKeybinding(binding)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Keymap[cmd] = kb
+	}
+	return cfg, nil
+}
+
+// LoadDefault attempts to read ~/.texteditor/config.yaml.
+func LoadDefault() (*Config, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return Default(), nil
+	}
+	path := filepath.Join(home, ".texteditor", "config.yaml")
+	return Load(path)
+}
+
+// ParseKeybinding converts a textual key description like "Ctrl+S" into a
+// Keybinding. Currently only Ctrl+<letter> is supported.
+func ParseKeybinding(s string) (Keybinding, error) {
+	parts := strings.Split(s, "+")
+	if len(parts) != 2 {
+		return Keybinding{}, errors.New("invalid keybinding: " + s)
+	}
+	if !strings.EqualFold(parts[0], "ctrl") {
+		return Keybinding{}, errors.New("invalid modifier in keybinding: " + s)
+	}
+	r := []rune(strings.ToLower(parts[1]))
+	if len(r) != 1 || r[0] < 'a' || r[0] > 'z' {
+		return Keybinding{}, errors.New("invalid key in keybinding: " + s)
+	}
+	return Keybinding{Key: tcell.KeyRune, Rune: r[0], Mod: tcell.ModCtrl}, nil
+}
+
+func mustParse(s string) Keybinding {
+	kb, _ := ParseKeybinding(s)
+	return kb
+}
+
+var ctrlMap = map[rune]tcell.Key{
+	'a': tcell.KeyCtrlA,
+	'b': tcell.KeyCtrlB,
+	'c': tcell.KeyCtrlC,
+	'd': tcell.KeyCtrlD,
+	'e': tcell.KeyCtrlE,
+	'f': tcell.KeyCtrlF,
+	'g': tcell.KeyCtrlG,
+	'h': tcell.KeyCtrlH,
+	'i': tcell.KeyCtrlI,
+	'j': tcell.KeyCtrlJ,
+	'k': tcell.KeyCtrlK,
+	'l': tcell.KeyCtrlL,
+	'm': tcell.KeyCtrlM,
+	'n': tcell.KeyCtrlN,
+	'o': tcell.KeyCtrlO,
+	'p': tcell.KeyCtrlP,
+	'q': tcell.KeyCtrlQ,
+	'r': tcell.KeyCtrlR,
+	's': tcell.KeyCtrlS,
+	't': tcell.KeyCtrlT,
+	'u': tcell.KeyCtrlU,
+	'v': tcell.KeyCtrlV,
+	'w': tcell.KeyCtrlW,
+	'x': tcell.KeyCtrlX,
+	'y': tcell.KeyCtrlY,
+	'z': tcell.KeyCtrlZ,
+}
+
+// Matches returns true if the binding matches the provided event.
+func (k Keybinding) Matches(ev *tcell.EventKey) bool {
+	if k.Key == ev.Key() && k.Rune == ev.Rune() && k.Mod == ev.Modifiers() {
+		return true
+	}
+	if k.Key == tcell.KeyRune && k.Mod == tcell.ModCtrl {
+		if ctrlKey, ok := ctrlMap[k.Rune]; ok && ev.Key() == ctrlKey {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestParseKeybinding(t *testing.T) {
+	kb, err := ParseKeybinding("Ctrl+X")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	ev := tcell.NewEventKey(tcell.KeyRune, 'x', tcell.ModCtrl)
+	if !kb.Matches(ev) {
+		t.Fatalf("expected match for Ctrl+X")
+	}
+}
+
+func TestParseKeybinding_Invalid(t *testing.T) {
+	if _, err := ParseKeybinding("Ctrl+"); err == nil {
+		t.Fatalf("expected error for invalid keybinding")
+	}
+}
+
+func TestLoadConfigRemap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	data := []byte("keymap:\n  quit: Ctrl+X\n")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	ev := tcell.NewEventKey(tcell.KeyRune, 'x', tcell.ModCtrl)
+	if !cfg.Keymap["quit"].Matches(ev) {
+		t.Fatalf("expected remapped quit to Ctrl+X")
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -430,13 +430,9 @@ Completed (high level)
 - M3: Search and go-to: incremental highlights, Enter to jump; Alt+G go-to.
 - M4: Kill/yank and undo/redo v1: Ctrl+K, Ctrl+U/Ctrl+Y, Ctrl+Z/Ctrl+Y; single-slot kill ring.
 - Extras: Help screen (F1/Ctrl+H), dirty-quit confirmation, basic normal/insert/visual modes, logging hooks.
+- M5: Config and keymaps: load ~/.texteditor/config.yaml to remap quit/save/search.
 
 Next Milestones (proposal)
-- M5 — Config & Keymaps
-  - Tasks: add pkg/config loader (YAML), define keymap structure, remap handlers in internal/app/runner.go via a dispatch table.
-  - Files: pkg/config/*, pkg/input/keymap.go (or fold into app), internal/app/runner.go (use keymap), readme.md.
-  - Acceptance: user can remap at least save/quit/search; invalid configs fail with a clear status message; unit tests for key resolution.
-
 - M6 — Multiple Buffers & Simple Windowing
   - Tasks: introduce an Editor orchestrator holding buffers; add open-in-new-buffer, buffer switcher, and optional single split.
   - Files: pkg/editor/editor.go, internal/app/runner.go (route to focused buffer), internal/app/*_ui.go (update prompts), tests for focus/render state.


### PR DESCRIPTION
## Summary
- allow key remapping via new pkg/config loader
- wire Runner and CLI to use configurable keymaps
- document config milestone in README and add keymap tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899742d4d98832d83181ac684e90ba9