### PR TITLE
Introduce asynchronous event loop and renderer

### DIFF
--- a/internal/app/open_ui.go
+++ b/internal/app/open_ui.go
@@ -10,7 +10,6 @@ func (r *Runner) runOpenPrompt() {
 	if r.Screen == nil {
 		return
 	}
-	s := r.Screen
 	input := ""
 	errMsg := ""
 	for {
@@ -23,7 +22,7 @@ func (r *Runner) runOpenPrompt() {
 		r.setMiniBuffer(lines)
 		r.draw(nil)
 
-		ev := s.PollEvent()
+		ev := r.waitEvent()
 		switch ev := ev.(type) {
 		case *tcell.EventKey:
 			// Cancel

--- a/internal/app/quit_ui.go
+++ b/internal/app/quit_ui.go
@@ -8,11 +8,10 @@ func (r *Runner) runQuitPrompt() bool {
 	if r.Screen == nil {
 		return true
 	}
-	s := r.Screen
 	r.setMiniBuffer([]string{"Unsaved changes. Quit without saving? (y/n)"})
 	r.draw(nil)
 	for {
-		ev := s.PollEvent()
+		ev := r.waitEvent()
 		switch ev := ev.(type) {
 		case *tcell.EventKey:
 			if ev.Key() == tcell.KeyEsc || (ev.Key() == tcell.KeyRune && (ev.Rune() == 'n' || ev.Rune() == 'N')) {

--- a/internal/app/runner_keys.go
+++ b/internal/app/runner_keys.go
@@ -128,11 +128,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 			r.Logger.Event("action", map[string]any{"name": "open.prompt"})
 		}
 		if r.Screen != nil {
-			if r.Buf != nil && r.Buf.Len() > 0 {
-				r.draw(nil)
-			} else {
-				drawUI(r.Screen)
-			}
+			r.draw(nil)
 		}
 		return false
 	}
@@ -142,11 +138,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 		bs := r.Ed.Prev()
 		r.FilePath, r.Buf, r.Cursor, r.Dirty = bs.FilePath, bs.Buf, bs.Cursor, bs.Dirty
 		if r.Screen != nil {
-			if r.Buf != nil && r.Buf.Len() > 0 {
-				r.draw(nil)
-			} else {
-				drawUI(r.Screen)
-			}
+			r.draw(nil)
 		}
 		return false
 	}
@@ -155,11 +147,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 		bs := r.Ed.Next()
 		r.FilePath, r.Buf, r.Cursor, r.Dirty = bs.FilePath, bs.Buf, bs.Cursor, bs.Dirty
 		if r.Screen != nil {
-			if r.Buf != nil && r.Buf.Len() > 0 {
-				r.draw(nil)
-			} else {
-				drawUI(r.Screen)
-			}
+			r.draw(nil)
 		}
 		return false
 	}
@@ -217,7 +205,7 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 			r.Logger.Event("action", map[string]any{"name": "help.show"})
 		}
 		if r.Screen != nil {
-			drawHelp(r.Screen)
+			r.draw(nil)
 		}
 		return false
 	}

--- a/internal/app/save_ui.go
+++ b/internal/app/save_ui.go
@@ -21,7 +21,6 @@ func (r *Runner) runSaveAsPrompt() {
 	if r.Screen == nil {
 		return
 	}
-	s := r.Screen
 	input := r.FilePath // prefill with current path if any
 	errMsg := ""
 	for {
@@ -34,7 +33,7 @@ func (r *Runner) runSaveAsPrompt() {
 		r.setMiniBuffer(lines)
 		r.draw(nil)
 
-		ev := s.PollEvent()
+		ev := r.waitEvent()
 		switch ev := ev.(type) {
 		case *tcell.EventKey:
 			if ev.Key() == tcell.KeyEsc {

--- a/internal/app/search_ui.go
+++ b/internal/app/search_ui.go
@@ -15,10 +15,8 @@ func (r *Runner) runSearchPrompt() {
 	if r.Screen == nil {
 		return
 	}
-	s := r.Screen
 	query := ""
 	for {
-		// compute highlight ranges for current query
 		text := r.Buf.String()
 		var ranges []search.Range
 		if query != "" {
@@ -33,10 +31,9 @@ func (r *Runner) runSearchPrompt() {
 			}
 		}
 		r.setMiniBuffer(lines)
-		// redraw buffer (with highlights) and mini-buffer
 		r.draw(ranges)
 
-		ev := s.PollEvent()
+		ev := r.waitEvent()
 		switch ev := ev.(type) {
 		case *tcell.EventKey:
 			// Cancel


### PR DESCRIPTION
## Summary
- Start concurrency support by adding EventCh and RenderCh to the runner
- Drive a new goroutine to poll terminal events and a renderer goroutine to draw snapshots
- Update prompts and dialogs to use the shared event channel instead of polling the screen

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_689b08c7a364832d865d039db66e8b80