### PR TITLE
Add mnemonic key-based command menu

### DIFF
--- a/internal/app/mnemonic_menu.go
+++ b/internal/app/mnemonic_menu.go
@@ -1,0 +1,128 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+type mnemonicNode struct {
+	key      rune
+	name     string
+	action   func() bool
+	children []*mnemonicNode
+}
+
+func (r *Runner) mnemonicMenu() []*mnemonicNode {
+	return []*mnemonicNode{
+		{
+			key:  'f',
+			name: "file",
+			children: []*mnemonicNode{
+				{key: 'o', name: "open file", action: func() bool {
+					r.runOpenPrompt()
+					return false
+				}},
+				{key: 's', name: "save", action: func() bool {
+					if r.FilePath == "" {
+						r.runSaveAsPrompt()
+					} else {
+						if err := r.Save(); err == nil {
+							r.showDialog("Saved " + r.FilePath)
+						}
+					}
+					if r.Logger != nil {
+						r.Logger.Event("action", map[string]any{"name": "save", "file": r.FilePath})
+					}
+					return false
+				}},
+			},
+		},
+		{
+			key:  's',
+			name: "search",
+			children: []*mnemonicNode{
+				{key: 's', name: "search", action: func() bool {
+					r.runSearchPrompt()
+					return false
+				}},
+			},
+		},
+		{
+			key:  'g',
+			name: "go to",
+			children: []*mnemonicNode{
+				{key: 'l', name: "line", action: func() bool {
+					r.runGoToPrompt()
+					return false
+				}},
+			},
+		},
+		{key: 'h', name: "help", action: func() bool {
+			r.ShowHelp = true
+			r.draw(nil)
+			return false
+		}},
+		{key: 'q', name: "quit", action: func() bool {
+			if r.Dirty {
+				return r.runQuitPrompt()
+			}
+			return true
+		}},
+	}
+}
+
+func (r *Runner) runMnemonicMenu() bool {
+	if r.Screen == nil {
+		return false
+	}
+	root := &mnemonicNode{children: r.mnemonicMenu()}
+	node := root
+	path := ""
+	for {
+		lines := []string{"Keys: " + path}
+		for _, child := range node.children {
+			lines = append(lines, fmt.Sprintf(" %c - %s", child.key, child.name))
+		}
+		r.setMiniBuffer(lines)
+		r.draw(nil)
+
+		ev := r.waitEvent()
+		if ev == nil {
+			r.clearMiniBuffer()
+			r.draw(nil)
+			return false
+		}
+		if kev, ok := ev.(*tcell.EventKey); ok {
+			switch {
+			case kev.Key() == tcell.KeyEsc:
+				r.clearMiniBuffer()
+				r.draw(nil)
+				return false
+			case kev.Key() == tcell.KeyRune && kev.Rune() == ' ' && kev.Modifiers() == 0:
+				r.clearMiniBuffer()
+				r.draw(nil)
+				return r.runCommandMenu()
+			case kev.Key() == tcell.KeyRune && kev.Modifiers() == 0:
+				ch := kev.Rune()
+				var next *mnemonicNode
+				for _, child := range node.children {
+					if child.key == ch {
+						next = child
+						break
+					}
+				}
+				if next != nil {
+					if len(next.children) > 0 {
+						node = next
+						path += string(ch)
+					} else if next.action != nil {
+						r.clearMiniBuffer()
+						r.draw(nil)
+						return next.action()
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/app/runner_keys.go
+++ b/internal/app/runner_keys.go
@@ -89,7 +89,12 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 				r.draw(nil)
 			}
 			return false
+		case ' ':
+			return r.runMnemonicMenu()
 		}
+	}
+	if r.Mode == ModeInsert && ev.Key() == tcell.KeyRune && ev.Rune() == 'm' && ev.Modifiers() == tcell.ModAlt {
+		return r.runMnemonicMenu()
 	}
 	if r.Mode == ModeVisual && ev.Key() == tcell.KeyRune && ev.Rune() == 'v' && ev.Modifiers() == 0 {
 		r.Mode = ModeNormal

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ Interactive example (typical session):
  - Move the cursor with the arrow keys (or Ctrl+B/F/P/N), PageUp/PageDown, Home/End.
 - Search (incremental): press Ctrl+W, type a query — matches are highlighted in the viewport as you type; press Enter to jump to the current match, Esc to cancel.
 - Go to line: press Alt+G, enter a 1-based line number, press Enter to jump.
+- Mnemonic menu: press Space in normal mode or Alt+M in insert mode to open a mnemonic key menu; press Space within this menu to switch to the everything menu.
 - Save changes: press Ctrl+S.
 - Quit: press Ctrl+Q (the editor will prompt if the buffer is dirty in future milestones).
 


### PR DESCRIPTION
## Summary
- add mnemonic key menu triggered by Space in normal mode or Alt+M in insert mode
- space from mnemonic menu switches to the everything menu
- document mnemonic menu usage in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689bd6d3d0e8832da127b629b51c6d3c