### PR TITLE
Add Vim-style word boundary motions

### DIFF
--- a/internal/app/runner_keys.go
+++ b/internal/app/runner_keys.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"example.com/texteditor/pkg/buffer"
 	"example.com/texteditor/pkg/config"
 	"github.com/gdamore/tcell/v2"
 )
@@ -100,6 +101,33 @@ func (r *Runner) handleKeyEvent(ev *tcell.EventKey) bool {
 					last--
 				}
 				r.CursorLine = last
+			}
+			if r.Screen != nil {
+				r.draw(nil)
+			}
+			return false
+		case 'w':
+			if r.Buf != nil {
+				r.Cursor = buffer.NextWordStart(r.Buf, r.Cursor)
+				r.recomputeCursorLine()
+			}
+			if r.Screen != nil {
+				r.draw(nil)
+			}
+			return false
+		case 'b':
+			if r.Buf != nil {
+				r.Cursor = buffer.WordStart(r.Buf, r.Cursor)
+				r.recomputeCursorLine()
+			}
+			if r.Screen != nil {
+				r.draw(nil)
+			}
+			return false
+		case 'e':
+			if r.Buf != nil {
+				r.Cursor = buffer.WordEnd(r.Buf, r.Cursor)
+				r.recomputeCursorLine()
 			}
 			if r.Screen != nil {
 				r.draw(nil)
@@ -514,6 +542,27 @@ func (r *Runner) handleVisualKey(ev *tcell.EventKey) bool {
 				r.CursorLine++
 			}
 			r.Cursor++
+		}
+		r.draw(nil)
+		return false
+	case ev.Key() == tcell.KeyRune && ev.Rune() == 'w' && ev.Modifiers() == 0:
+		if r.Buf != nil {
+			r.Cursor = buffer.NextWordStart(r.Buf, r.Cursor)
+			r.recomputeCursorLine()
+		}
+		r.draw(nil)
+		return false
+	case ev.Key() == tcell.KeyRune && ev.Rune() == 'b' && ev.Modifiers() == 0:
+		if r.Buf != nil {
+			r.Cursor = buffer.WordStart(r.Buf, r.Cursor)
+			r.recomputeCursorLine()
+		}
+		r.draw(nil)
+		return false
+	case ev.Key() == tcell.KeyRune && ev.Rune() == 'e' && ev.Modifiers() == 0:
+		if r.Buf != nil {
+			r.Cursor = buffer.WordEnd(r.Buf, r.Cursor)
+			r.recomputeCursorLine()
 		}
 		r.draw(nil)
 		return false

--- a/internal/app/runner_test.go
+++ b/internal/app/runner_test.go
@@ -271,6 +271,35 @@ func TestLineNavigationNormalMode(t *testing.T) {
 	}
 }
 
+func TestWordMotionsNormalMode(t *testing.T) {
+	r := &Runner{Buf: buffer.NewGapBufferFromString("one two"), Mode: ModeNormal}
+
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'e', 0))
+	if r.Cursor != 2 {
+		t.Fatalf("expected cursor at 2 after 'e', got %d", r.Cursor)
+	}
+
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'w', 0))
+	if r.Cursor != 4 {
+		t.Fatalf("expected cursor at 4 after 'w', got %d", r.Cursor)
+	}
+
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'e', 0))
+	if r.Cursor != 6 {
+		t.Fatalf("expected cursor at 6 after second 'e', got %d", r.Cursor)
+	}
+
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'b', 0))
+	if r.Cursor != 4 {
+		t.Fatalf("expected cursor at 4 after 'b', got %d", r.Cursor)
+	}
+
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'b', 0))
+	if r.Cursor != 0 {
+		t.Fatalf("expected cursor at 0 after second 'b', got %d", r.Cursor)
+	}
+}
+
 func TestGotoTopAndBottomNormalMode(t *testing.T) {
 	r := &Runner{Buf: buffer.NewGapBufferFromString("abc\ndef\nghi"), Cursor: 5, Mode: ModeNormal}
 	r.recomputeCursorLine()

--- a/pkg/buffer/word.go
+++ b/pkg/buffer/word.go
@@ -1,0 +1,69 @@
+package buffer
+
+import "unicode"
+
+// IsWordRune reports whether r is considered part of a word.
+// Words consist of letters, digits, or underscore characters.
+func IsWordRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_'
+}
+
+// WordStart returns the index of the beginning of the word that ends at or before pos.
+// It behaves similar to Vim's 'b' motion.
+func WordStart(g *GapBuffer, pos int) int {
+	if g == nil || g.Len() == 0 {
+		return 0
+	}
+	if pos > g.Len() {
+		pos = g.Len()
+	}
+	if pos > 0 {
+		pos--
+	}
+	for pos > 0 && !IsWordRune(g.RuneAt(pos)) {
+		pos--
+	}
+	for pos > 0 && IsWordRune(g.RuneAt(pos-1)) {
+		pos--
+	}
+	return pos
+}
+
+// WordEnd returns the index of the end of the word that begins at or after pos.
+// It behaves similar to Vim's 'e' motion.
+func WordEnd(g *GapBuffer, pos int) int {
+	if g == nil || g.Len() == 0 {
+		return 0
+	}
+	if pos >= g.Len() {
+		return g.Len() - 1
+	}
+	for pos < g.Len() && !IsWordRune(g.RuneAt(pos)) {
+		pos++
+	}
+	for pos < g.Len() && IsWordRune(g.RuneAt(pos)) {
+		pos++
+	}
+	if pos > 0 {
+		pos--
+	}
+	return pos
+}
+
+// NextWordStart returns the index of the start of the next word after pos.
+// It behaves similar to Vim's 'w' motion.
+func NextWordStart(g *GapBuffer, pos int) int {
+	if g == nil || g.Len() == 0 {
+		return 0
+	}
+	if pos >= g.Len() {
+		return g.Len()
+	}
+	for pos < g.Len() && IsWordRune(g.RuneAt(pos)) {
+		pos++
+	}
+	for pos < g.Len() && !IsWordRune(g.RuneAt(pos)) {
+		pos++
+	}
+	return pos
+}


### PR DESCRIPTION
## Summary
- add reusable word boundary helpers (`WordStart`, `WordEnd`, `NextWordStart`)
- support `w`, `b`, and `e` motions in normal and visual modes
- test word-based navigation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689be5048034832d9a2dba334b08e66a