### PR TITLE
Handle visual mode Ctrl+U/D scrolling correctly

### DIFF
--- a/internal/app/runner_keys.go
+++ b/internal/app/runner_keys.go
@@ -537,6 +537,7 @@ func (r *Runner) handleVisualKey(ev *tcell.EventKey) bool {
 			}
 		}
 		r.moveCursorVertical(lines)
+		r.recomputeCursorLine()
 		r.draw(nil)
 		return false
 	case (ev.Key() == tcell.KeyRune && ev.Rune() == 'u' && ev.Modifiers() == tcell.ModCtrl) || ev.Key() == tcell.KeyCtrlU:
@@ -548,6 +549,7 @@ func (r *Runner) handleVisualKey(ev *tcell.EventKey) bool {
 			}
 		}
 		r.moveCursorVertical(-lines)
+		r.recomputeCursorLine()
 		r.draw(nil)
 		return false
 	case ev.Key() == tcell.KeyLeft || (ev.Key() == tcell.KeyRune && ev.Rune() == 'h' && ev.Modifiers() == 0):

--- a/internal/app/runner_test.go
+++ b/internal/app/runner_test.go
@@ -359,14 +359,21 @@ func TestVisualHalfPageMovement(t *testing.T) {
 	orig := r.Buf.String()
 	r.recomputeCursorLine()
 	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'v', 0))
-	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'd', tcell.ModCtrl))
+	start := r.Cursor
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyCtrlD, 0, 0))
 	if r.CursorLine != 10 {
 		t.Fatalf("expected cursor line 10 after Ctrl+D, got %d", r.CursorLine)
 	}
+	if r.Mode != ModeVisual || r.VisualStart != start {
+		t.Fatalf("expected to remain in visual mode after Ctrl+D")
+	}
 	r.KillRing.Set("ZZ")
-	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'u', tcell.ModCtrl))
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyCtrlU, 0, 0))
 	if r.CursorLine != 0 {
 		t.Fatalf("expected cursor line 0 after Ctrl+U, got %d", r.CursorLine)
+	}
+	if r.Mode != ModeVisual || r.VisualStart != start {
+		t.Fatalf("expected to remain in visual mode after Ctrl+U")
 	}
 	if got := r.Buf.String(); got != orig {
 		t.Fatalf("expected buffer unchanged after Ctrl+U, got %q", got)


### PR DESCRIPTION
## Summary
- keep cursor line in sync when scrolling half a page with Ctrl+U/D in visual mode
- exercise Ctrl+U and Ctrl+D (dedicated control keys) in visual-mode tests and ensure mode persistence

## Testing
- `go test ./internal/... -count=1`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689bee1c904c832da0a1c3c74c21f3f6