### PR TITLE
Fix 'e' word motion across word boundaries

### DIFF
--- a/internal/app/runner_test.go
+++ b/internal/app/runner_test.go
@@ -279,11 +279,6 @@ func TestWordMotionsNormalMode(t *testing.T) {
 		t.Fatalf("expected cursor at 2 after 'e', got %d", r.Cursor)
 	}
 
-	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'w', 0))
-	if r.Cursor != 4 {
-		t.Fatalf("expected cursor at 4 after 'w', got %d", r.Cursor)
-	}
-
 	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'e', 0))
 	if r.Cursor != 6 {
 		t.Fatalf("expected cursor at 6 after second 'e', got %d", r.Cursor)
@@ -297,6 +292,25 @@ func TestWordMotionsNormalMode(t *testing.T) {
 	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'b', 0))
 	if r.Cursor != 0 {
 		t.Fatalf("expected cursor at 0 after second 'b', got %d", r.Cursor)
+	}
+
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'w', 0))
+	if r.Cursor != 4 {
+		t.Fatalf("expected cursor at 4 after 'w', got %d", r.Cursor)
+	}
+}
+
+func TestWordEndVisualMode(t *testing.T) {
+	r := &Runner{Buf: buffer.NewGapBufferFromString("one two"), Mode: ModeVisual, VisualStart: 0}
+
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'e', 0))
+	if r.Cursor != 2 {
+		t.Fatalf("expected cursor at 2 after 'e', got %d", r.Cursor)
+	}
+
+	r.handleKeyEvent(tcell.NewEventKey(tcell.KeyRune, 'e', 0))
+	if r.Cursor != 6 {
+		t.Fatalf("expected cursor at 6 after second 'e', got %d", r.Cursor)
 	}
 }
 

--- a/pkg/buffer/word.go
+++ b/pkg/buffer/word.go
@@ -38,6 +38,9 @@ func WordEnd(g *GapBuffer, pos int) int {
 	if pos >= g.Len() {
 		return g.Len() - 1
 	}
+	if IsWordRune(g.RuneAt(pos)) && (pos == g.Len()-1 || !IsWordRune(g.RuneAt(pos+1))) {
+		pos++
+	}
 	for pos < g.Len() && !IsWordRune(g.RuneAt(pos)) {
 		pos++
 	}

--- a/pkg/buffer/word_test.go
+++ b/pkg/buffer/word_test.go
@@ -1,0 +1,17 @@
+package buffer
+
+import "testing"
+
+func TestWordEndAtWordBoundary(t *testing.T) {
+	g := NewGapBufferFromString("one two")
+	if got := WordEnd(g, 2); got != 6 {
+		t.Fatalf("expected 6, got %d", got)
+	}
+}
+
+func TestWordEndInsideWord(t *testing.T) {
+	g := NewGapBufferFromString("one")
+	if got := WordEnd(g, 1); got != 2 {
+		t.Fatalf("expected 2, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary
- advance `WordEnd` past current word when invoked on its last character
- test `e` motion at word boundaries in normal and visual modes
- cover boundary cases with buffer-level unit tests

## Testing
- `go test ./pkg/buffer -count=1`
- `go test ./internal/app -count=1`
- `go test ./cmd/texteditor -count=1`


------
https://chatgpt.com/codex/tasks/task_e_689bf12935c8832d8fd6c91ce9e9cf8d