### PR TITLE
Add plugin manager and tree-sitter parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,18 @@ module example.com/texteditor
 
 go 1.22
 
-require github.com/gdamore/tcell/v2 v2.8.1
+require (
+    github.com/gdamore/tcell/v2 v2.8.1
+    github.com/smacker/go-tree-sitter v0.20.1
+)
 
 require (
-	github.com/gdamore/encoding v1.0.1 // indirect
-	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
-	github.com/mattn/go-runewidth v0.0.16 // indirect
-	github.com/rivo/uniseg v0.4.3 // indirect
-	golang.org/x/sys v0.29.0 // indirect
-	golang.org/x/term v0.28.0 // indirect
-	golang.org/x/text v0.21.0 // indirect
+        github.com/gdamore/encoding v1.0.1 // indirect
+        github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+        github.com/mattn/go-runewidth v0.0.16 // indirect
+        github.com/rivo/uniseg v0.4.3 // indirect
+        golang.org/x/sys v0.29.0 // indirect
+        golang.org/x/term v0.28.0 // indirect
+        golang.org/x/text v0.21.0 // indirect
 )
+

--- a/pkg/plugins/manager.go
+++ b/pkg/plugins/manager.go
@@ -1,0 +1,44 @@
+package plugins
+
+import sitter "github.com/smacker/go-tree-sitter"
+
+// Plugin represents a generic extension component.
+type Plugin interface {
+	Name() string
+}
+
+// SyntaxPlugin provides parsing capabilities using tree-sitter.
+type SyntaxPlugin interface {
+	Plugin
+	Parse(src []byte) *sitter.Tree
+}
+
+// Manager keeps track of registered plug-ins.
+type Manager struct {
+	registry map[string]Plugin
+}
+
+// NewManager creates an empty plug-in registry.
+func NewManager() *Manager {
+	return &Manager{registry: make(map[string]Plugin)}
+}
+
+// Register adds a plug-in to the registry.
+func (m *Manager) Register(p Plugin) {
+	m.registry[p.Name()] = p
+}
+
+// Get retrieves a plug-in by name.
+func (m *Manager) Get(name string) (Plugin, bool) {
+	p, ok := m.registry[name]
+	return p, ok
+}
+
+// List returns all registered plug-ins.
+func (m *Manager) List() []Plugin {
+	out := make([]Plugin, 0, len(m.registry))
+	for _, p := range m.registry {
+		out = append(out, p)
+	}
+	return out
+}

--- a/pkg/plugins/treesitter.go
+++ b/pkg/plugins/treesitter.go
@@ -1,0 +1,26 @@
+package plugins
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/golang"
+)
+
+// TreeSitterPlugin wraps a tree-sitter parser for Go code.
+type TreeSitterPlugin struct {
+	parser *sitter.Parser
+}
+
+// NewTreeSitterPlugin initializes the parser with the Go language grammar.
+func NewTreeSitterPlugin() *TreeSitterPlugin {
+	p := sitter.NewParser()
+	p.SetLanguage(golang.GetLanguage())
+	return &TreeSitterPlugin{parser: p}
+}
+
+// Name identifies the plugin.
+func (t *TreeSitterPlugin) Name() string { return "tree-sitter-go" }
+
+// Parse returns a syntax tree for the provided source code.
+func (t *TreeSitterPlugin) Parse(src []byte) *sitter.Tree {
+	return t.parser.Parse(nil, src)
+}

--- a/pkg/plugins/treesitter_test.go
+++ b/pkg/plugins/treesitter_test.go
@@ -1,0 +1,21 @@
+package plugins
+
+import "testing"
+
+func TestTreeSitterParse(t *testing.T) {
+	ts := NewTreeSitterPlugin()
+	code := []byte("package main\nfunc main() {}\n")
+	tree := ts.Parse(code)
+	if tree.RootNode().Type() != "source_file" {
+		t.Fatalf("expected source_file, got %s", tree.RootNode().Type())
+	}
+}
+
+func TestManagerRegister(t *testing.T) {
+	m := NewManager()
+	ts := NewTreeSitterPlugin()
+	m.Register(ts)
+	if _, ok := m.Get(ts.Name()); !ok {
+		t.Fatalf("tree-sitter plugin not registered")
+	}
+}


### PR DESCRIPTION
## Summary
- add simple plug-in manager with registration and lookup
- wire up a tree-sitter based parser plug-in for Go syntax
- document tree-sitter requirement in module dependencies

## Testing
- `go mod tidy` *(fails: module github.com/smacker/go-tree-sitter: Get "https://proxy.golang.org/github.com/smacker/go-tree-sitter/@v/list": Forbidden)*
- `go test ./...` *(fails: missing go.sum entry for github.com/smacker/go-tree-sitter)*

------
https://chatgpt.com/codex/tasks/task_e_689bf7ad128c832d859985141186d92d