### PR TITLE
Improve tree-sitter syntax highlighting and caching

### DIFF
--- a/internal/app/runner_syntax.go
+++ b/internal/app/runner_syntax.go
@@ -13,10 +13,10 @@ func (r *Runner) syntaxHighlights() []search.Range {
 	if r.Buf == nil {
 		return nil
 	}
-	if r.syntaxCache != nil && r.syntaxSrc != "" {
+	src := r.Buf.String()
+	if r.syntaxCache != nil && r.syntaxSrc == src {
 		return r.syntaxCache
 	}
-	src := r.Buf.String()
 	if r.Syntax == nil {
 		r.Syntax = plugins.NewTreeSitterPlugin()
 	}

--- a/internal/app/runner_syntax_test.go
+++ b/internal/app/runner_syntax_test.go
@@ -1,0 +1,40 @@
+//go:build tree_sitter
+
+package app
+
+import (
+	"testing"
+
+	"example.com/texteditor/pkg/buffer"
+	"example.com/texteditor/pkg/search"
+)
+
+type fakeHighlighter struct{ calls int }
+
+func (f *fakeHighlighter) Name() string { return "fake" }
+func (f *fakeHighlighter) Highlight(src []byte) []search.Range {
+	f.calls++
+	return []search.Range{}
+}
+
+func TestSyntaxHighlightsCacheInvalidation(t *testing.T) {
+	r := &Runner{Buf: buffer.NewGapBufferFromString("package main\n")}
+	fh := &fakeHighlighter{}
+	r.Syntax = fh
+
+	r.syntaxHighlights()
+	if fh.calls != 1 {
+		t.Fatalf("expected first call to run highlighter, got %d", fh.calls)
+	}
+	r.syntaxHighlights()
+	if fh.calls != 1 {
+		t.Fatalf("expected cached highlights, got %d", fh.calls)
+	}
+	if err := r.Buf.Insert(0, []rune("func ")); err != nil {
+		t.Fatalf("insert failed: %v", err)
+	}
+	r.syntaxHighlights()
+	if fh.calls != 2 {
+		t.Fatalf("expected cache invalidation after edit, got %d", fh.calls)
+	}
+}

--- a/pkg/plugins/treesitter.go
+++ b/pkg/plugins/treesitter.go
@@ -57,7 +57,7 @@ func (t *TreeSitterPlugin) Highlight(src []byte) []search.Range {
 		if _, ok := keywords[typ]; ok {
 			ranges = append(ranges, search.Range{Start: int(n.StartByte()), End: int(n.EndByte())})
 		}
-		if typ == "comment" {
+		if typ == "comment" || typ == "interpreted_string_literal" || typ == "raw_string_literal" {
 			ranges = append(ranges, search.Range{Start: int(n.StartByte()), End: int(n.EndByte())})
 		}
 		for i := 0; i < int(n.ChildCount()); i++ {

--- a/pkg/plugins/treesitter_test.go
+++ b/pkg/plugins/treesitter_test.go
@@ -2,7 +2,10 @@
 
 package plugins
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func TestTreeSitterParse(t *testing.T) {
 	ts := NewTreeSitterPlugin()
@@ -24,20 +27,27 @@ func TestManagerRegister(t *testing.T) {
 
 func TestTreeSitterHighlight(t *testing.T) {
 	ts := NewTreeSitterPlugin()
-	code := []byte("package main\nfunc main() {return}\n")
+	code := []byte("package main\nfunc main() {return \"hi\"}\n")
 	ranges := ts.Highlight(code)
 	if len(ranges) == 0 {
 		t.Fatalf("expected highlights, got none")
 	}
-	// ensure the \"func\" keyword is highlighted
-	found := false
+	funcOff := bytes.Index(code, []byte("func"))
+	strOff := bytes.Index(code, []byte("\"hi\""))
+	funcFound := false
+	strFound := false
 	for _, r := range ranges {
-		if r.Start == 13 { // byte offset of "func"
-			found = true
-			break
+		if r.Start == funcOff {
+			funcFound = true
+		}
+		if r.Start == strOff {
+			strFound = true
 		}
 	}
-	if !found {
+	if !funcFound {
 		t.Fatalf("expected func keyword to be highlighted")
+	}
+	if !strFound {
+		t.Fatalf("expected string literal to be highlighted")
 	}
 }


### PR DESCRIPTION
## Summary
- fix Runner syntax highlight cache to invalidate when buffer changes
- highlight Go string literals via tree-sitter plugin
- add tests for tree-sitter highlighting and cache invalidation

## Testing
- `go test ./... -run . -count=1`
- `go test ./... -run . -count=1 -tags tree_sitter`


------
https://chatgpt.com/codex/tasks/task_e_689c128bbf0c832dba91c1fb9018b4df