### PR TITLE
Move macro recording indicator to status bar (red <R> at right)

### DIFF
--- a/internal/app/runner_draw_test.go
+++ b/internal/app/runner_draw_test.go
@@ -93,7 +93,7 @@ func TestDrawBuffer_MiniBuffer(t *testing.T) {
 	}
 }
 
-func TestDrawFile_MacroStatusLine(t *testing.T) {
+func TestDrawFile_MacroRecordingIndicator(t *testing.T) {
 	s := tcell.NewSimulationScreen("UTF-8")
 	if err := s.Init(); err != nil {
 		t.Fatalf("initializing simulation screen failed: %v", err)
@@ -105,11 +105,16 @@ func TestDrawFile_MacroStatusLine(t *testing.T) {
 	macroStatus := "Recording macro @a"
 	drawFile(s, "f.txt", lines, nil, -1, false, ModeNormal, OverlayNone, 0, nil, config.DefaultTheme(), macroStatus)
 
-	_, height := s.Size()
-	for i, r := range macroStatus {
-		cr, _, _, _ := s.GetContent(i, height-1)
+	width, height := s.Size()
+	startX := width - len([]rune(macroRecordingIndicator))
+	expectedStyle := tcell.StyleDefault.Foreground(tcell.ColorRed).Background(config.DefaultTheme().StatusBackground)
+	for i, r := range macroRecordingIndicator {
+		cr, _, style, _ := s.GetContent(startX+i, height-1)
 		if cr != r {
-			t.Fatalf("expected macro status %q at %d, got %q", string(r), i, string(cr))
+			t.Fatalf("expected macro indicator %q at %d, got %q", string(r), startX+i, string(cr))
+		}
+		if style != expectedStyle {
+			t.Fatalf("expected macro indicator style at %d, got %v", startX+i, style)
 		}
 	}
 }

--- a/internal/app/runner_run_test.go
+++ b/internal/app/runner_run_test.go
@@ -446,7 +446,7 @@ func TestRun_MnemonicMenuMacroRecord_Simulation(t *testing.T) {
 
 	statusLine := "Recording macro @b"
 	waitForMacroStatus(t, r, statusLine)
-	assertMacroStatusRow(t, s, statusLine)
+	assertMacroRecordingIndicator(t, s)
 
 	t.Logf("macro status snapshot: %q", r.MacroStatus)
 
@@ -477,14 +477,15 @@ func waitForMacroStatus(t *testing.T, r *Runner, want string) {
 	}
 }
 
-func assertMacroStatusRow(t *testing.T, s tcell.Screen, statusLine string) {
+func assertMacroRecordingIndicator(t *testing.T, s tcell.Screen) {
 	t.Helper()
 	deadline := time.After(500 * time.Millisecond)
 	for {
-		_, height := s.Size()
+		width, height := s.Size()
 		match := true
-		for i, r := range statusLine {
-			cr, _, _, _ := s.GetContent(i, height-1)
+		startX := width - len([]rune(macroRecordingIndicator))
+		for i, r := range macroRecordingIndicator {
+			cr, _, _, _ := s.GetContent(startX+i, height-1)
 			if cr != r {
 				match = false
 				break
@@ -495,9 +496,10 @@ func assertMacroStatusRow(t *testing.T, s tcell.Screen, statusLine string) {
 		}
 		select {
 		case <-deadline:
-			_, height := s.Size()
-			cr, _, _, _ := s.GetContent(0, height-1)
-			t.Fatalf("expected macro status %q at 0, got %q", string(statusLine[0]), string(cr))
+			width, height := s.Size()
+			startX := width - len([]rune(macroRecordingIndicator))
+			cr, _, _, _ := s.GetContent(startX, height-1)
+			t.Fatalf("expected macro indicator %q at %d, got %q", string(macroRecordingIndicator[0]), startX, string(cr))
 		case <-time.After(10 * time.Millisecond):
 		}
 	}


### PR DESCRIPTION
### Motivation
- Move the macro recording indicator off its own bottom line and show a compact red `"<R>"` indicator on the main status line at the bottom-right, so the UI uses a single status area.

### Description
- Render a right-aligned red `"<R>"` indicator when recording by adding `macroRecordingIndicator` and `drawMacroRecordingIndicator` and using `isMacroRecording` to detect recording state.
- Ensure the main status text is truncated to make room for the indicator by adding `truncateStatusForIndicator` and calling it from `drawFile`/`drawUI` where status text is composed.
- Remove the previous separate macro mini-line rendering and wire the new indicator into `drawUI` and `drawFile` so the indicator appears on the same status row as other UI elements.
- Update tests that asserted the old full-line macro status: `TestDrawFile_MacroRecordingIndicator` now checks the indicator glyph and style, and `TestRun_MnemonicMenuMacroRecord_Simulation` uses `assertMacroRecordingIndicator` to validate placement.

### Testing
- No automated tests were executed as part of this change; unit tests were updated (`TestDrawFile_MacroRecordingIndicator`, `TestRun_MnemonicMenuMacroRecord_Simulation`) but not run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c4b36894c832da9ff414e6c0dde55)